### PR TITLE
Use workspace lint configuration.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/Indra-db/flecs_ecs_rs"
 
+[workspace.lints]
+clippy.doc_markdown = "warn"
+clippy.semicolon_if_nothing_returned = "warn"
+
 #[profile.release]
 #opt-level = 3
 #lto = true

--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -9,6 +9,9 @@ description = "Rust API for the C/CPP flecs ECS library <https://github.com/Sand
 keywords = ["ecs", "flecs", "entity-component-system", "game-development", "gamedev", "simulation", "performance", "game-engine"]
 categories = ["game-development", "api-bindings", "simulation", "development-tools::game-engines", "data-structures"]
 
+[lints]
+workspace = true
+
 [dependencies]
 flecs_ecs_derive = { path = "../flecs_ecs_derive" }
 flecs_ecs_sys = { path = "../flecs_ecs_sys" }

--- a/flecs_ecs/src/lib.rs
+++ b/flecs_ecs/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![warn(clippy::doc_markdown, clippy::semicolon_if_nothing_returned)]
 
 pub use flecs_ecs_derive as macros;
 pub use flecs_ecs_sys as sys;

--- a/flecs_ecs_derive/Cargo.toml
+++ b/flecs_ecs_derive/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 proc-macro = true
 name = "flecs_ecs_derive"
 
+[lints]
+workspace = true
+
 [dependencies]
 syn = "2.0.33"
 quote = "1.0.33"

--- a/flecs_ecs_sys/Cargo.toml
+++ b/flecs_ecs_sys/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["External FFI bindings",]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 libc = "0.2.153"
 


### PR DESCRIPTION
This helps ensure that the same lint configuration is used throughout all of the crates, examples, etc.