### PR TITLE
emit event as const by default, add `_mut` variants.

### DIFF
--- a/flecs_ecs/examples/observer_entity_event.rs
+++ b/flecs_ecs/examples/observer_entity_event.rs
@@ -75,7 +75,7 @@ fn main() {
     });
 
     widget.emit::<Click>();
-    widget.emit_payload(&mut Resize {
+    widget.emit_payload(&Resize {
         width: 100.0,
         height: 200.0,
     });

--- a/flecs_ecs/src/core/entity_view.rs
+++ b/flecs_ecs/src/core/entity_view.rs
@@ -1766,11 +1766,29 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_view::emit`
     #[doc(alias = "entity_view::emit")]
-    pub fn emit_payload<T: NotEmptyComponent + ComponentId>(self, payload: &mut T) {
+    pub fn emit_payload<T: NotEmptyComponent + ComponentId>(self, payload: &T) {
         self.world()
             .event::<T>()
             .set_entity_to_emit(self.to_entity())
             .set_event_data(payload)
+            .emit();
+    }
+
+    /// Emit event with mutable payload for entity.
+    ///
+    /// # Type Parameters
+    ///
+    /// * T - the event type to emit. Type must contain data (not empty struct).
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `entity_view::emit`
+    #[doc(alias = "entity_view::emit")]
+    pub fn emit_payload_mut<T: NotEmptyComponent + ComponentId>(self, payload: &mut T) {
+        self.get_world()
+            .event::<T>()
+            .set_entity_to_emit(&self.entity())
+            .set_event_data_mut(payload)
             .emit();
     }
 
@@ -1841,11 +1859,28 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_view::enqueue`
     #[doc(alias = "entity_view::enqueue")]
-    pub fn enqueue_payload<T: NotEmptyComponent + ComponentId>(self, payload: &mut T) {
+    pub fn enqueue_payload<T: NotEmptyComponent + ComponentId>(self, payload: &T) {
         self.world()
             .event::<T>()
             .set_entity_to_emit(self.to_entity())
             .set_event_data(payload)
+            .enqueue();
+    }
+    /// enqueue event with mutable payload for entity.
+    ///
+    /// # Type Parameters
+    ///
+    /// * T - the event type to enqueue. Type must contain data (not empty struct).
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `entity_view::enqueue`
+    #[doc(alias = "entity_view::enqueue")]
+    pub fn enqueue_payload_mut<T: NotEmptyComponent + ComponentId>(self, payload: &mut T) {
+        self.get_world()
+            .event::<T>()
+            .set_entity_to_emit(&self.entity())
+            .set_event_data_mut(payload)
             .enqueue();
     }
 }

--- a/flecs_ecs/src/core/event.rs
+++ b/flecs_ecs/src/core/event.rs
@@ -144,5 +144,6 @@ pub trait EventBuilderImpl<'a> {
         };
     }
 
-    fn set_event_data(&mut self, data: Self::BuiltType) -> &mut Self;
+    fn set_event_data_mut(&mut self, data: Self::BuiltType) -> &mut Self;
+    fn set_event_data(&mut self, data: Self::ConstBuiltType) -> &mut Self;
 }

--- a/flecs_ecs/src/core/event_builder.rs
+++ b/flecs_ecs/src/core/event_builder.rs
@@ -55,7 +55,7 @@ impl<'a> EventBuilderImpl<'a> for EventBuilder<'a> {
         self
     }
 
-    /// Set the event data for the event
+    /// Set the mutable event data for the event
     ///
     /// # Arguments
     ///
@@ -65,8 +65,23 @@ impl<'a> EventBuilderImpl<'a> for EventBuilder<'a> {
     ///
     /// * C++ API: `event_builder_base::ctx`
     #[doc(alias = "event_builder_base::ctx")]
-    fn set_event_data(&mut self, data: Self::BuiltType) -> &mut Self {
+    fn set_event_data_mut(&mut self, data: Self::BuiltType) -> &mut Self {
         self.desc.param = data as *mut c_void;
+        self
+    }
+
+    /// Set the const event data for the event
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to set for the event which is type-erased of type `*const c_void`
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `event_builder_base::ctx`
+    #[doc(alias = "event_builder_base::ctx")]
+    fn set_event_data(&mut self, data: Self::ConstBuiltType) -> &mut Self {
+        self.desc.const_param = data as *const c_void;
         self
     }
 }
@@ -132,7 +147,7 @@ where
     fn get_data(&mut self) -> &mut EventBuilder<'a> {
         &mut self.builder
     }
-    /// Set the event data for the event
+    /// Set the mutable event data for the event
     ///
     /// # Arguments
     ///
@@ -142,8 +157,18 @@ where
     ///
     /// * C++ API: `event_builder_typed::ctx`
     #[doc(alias = "event_builder_typed::ctx")]
+<<<<<<< HEAD
     fn set_event_data(&mut self, data: Self::BuiltType) -> &mut Self {
         self.desc.param = data as *const T as *mut c_void;
+=======
+    fn set_event_data_mut(&mut self, data: Self::BuiltType) -> &mut Self {
+        self.desc.param = data as *mut T as *mut c_void;
+        self
+    }
+
+    fn set_event_data(&mut self, data: Self::ConstBuiltType) -> &mut Self {
+        self.desc.const_param = data as *const T as *const c_void;
+>>>>>>> b9e10d4 (emit event as const by default, add `_mut` variants.)
         self
     }
 }


### PR DESCRIPTION
This doesn't change the observe-side.