### PR TITLE
Encourage better float comparisons.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ repository = "https://github.com/Indra-db/flecs_ecs_rs"
 
 [workspace.lints]
 clippy.doc_markdown = "warn"
+clippy.float_cmp = "warn"
+clippy.float_cmp_const = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 
 [profile.release]

--- a/flecs_ecs/examples/query_find_entity.rs
+++ b/flecs_ecs/examples/query_find_entity.rs
@@ -17,7 +17,7 @@ fn main() {
     // Create a simple query for component Position
     let query = world.query::<(&Position,)>();
 
-    let entity: Option<Entity> = query.find(|(pos,)| pos.x == 20.0);
+    let entity: Option<Entity> = query.find(|(pos,)| (pos.x - 20.0).abs() < f32::EPSILON);
 
     if let Some(entity) = entity {
         println!("Entity found: {:?}", entity.path().unwrap());


### PR DESCRIPTION
This enables some clippy checks and modifies the examples to pass these lints with no warnings.