### PR TITLE
Trap closure lifetimes of component references within the closure they are borrowed in.

### DIFF
--- a/flecs_ecs/examples/query_sorting.rs
+++ b/flecs_ecs/examples/query_sorting.rs
@@ -13,7 +13,7 @@ extern "C" fn compare_position(
     (p1.x > p2.x) as i32 - (p1.x < p2.x) as i32
 }
 
-fn print_query(query: &Query<'_, &Position>) {
+fn print_query(query: &Query<&Position>) {
     query.each(|pos| println!("{:?}", pos));
 }
 

--- a/flecs_ecs/src/addons/pipeline/mod.rs
+++ b/flecs_ecs/src/addons/pipeline/mod.rs
@@ -13,17 +13,17 @@ use crate::{
 };
 
 /// Pipelines order and schedule systems for execution.
-pub struct Pipeline<'a, T>
+pub struct Pipeline<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     pub entity: Entity,
-    phantom: std::marker::PhantomData<&'a T>,
+    phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> Deref for Pipeline<'a, T>
+impl<T> Deref for Pipeline<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     type Target = Entity;
 
@@ -33,9 +33,9 @@ where
     }
 }
 
-impl<'a, T> DerefMut for Pipeline<'a, T>
+impl<T> DerefMut for Pipeline<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -43,9 +43,9 @@ where
     }
 }
 
-impl<'a, T> Pipeline<'a, T>
+impl<T> Pipeline<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new pipeline.
     ///

--- a/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
+++ b/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
@@ -15,21 +15,21 @@ use crate::{
 
 use super::Pipeline;
 
-pub struct PipelineBuilder<'a, T>
+pub struct PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    query_builder: QueryBuilder<'a, T>,
+    query_builder: QueryBuilder<T>,
     desc: ecs_pipeline_desc_t,
     is_instanced: bool,
 }
 
 /// Deref to `QueryBuilder` to allow access to `QueryBuilder` methods without having to access `QueryBuilder` through `PipelineBuilder`
-impl<'a, T> Deref for PipelineBuilder<'a, T>
+impl<T> Deref for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type Target = QueryBuilder<'a, T>;
+    type Target = QueryBuilder<T>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -37,9 +37,9 @@ where
     }
 }
 
-impl<'a, T> DerefMut for PipelineBuilder<'a, T>
+impl<T> DerefMut for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -47,9 +47,9 @@ where
     }
 }
 
-impl<'a, T> PipelineBuilder<'a, T>
+impl<T> PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     pub fn new(world: &World) -> Self {
         let mut desc = Default::default();
@@ -134,9 +134,9 @@ where
         obj
     }
 }
-impl<'a, T> Filterable for PipelineBuilder<'a, T>
+impl<T> Filterable for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn current_term(&mut self) -> &mut TermT {
         unsafe { &mut *self.filter_builder.term.term_ptr }
@@ -147,9 +147,9 @@ where
     }
 }
 
-impl<'a, T> TermBuilder for PipelineBuilder<'a, T>
+impl<T> TermBuilder for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn world_ptr_mut(&self) -> *mut WorldT {
@@ -172,20 +172,20 @@ where
     }
 }
 
-impl<'a, T> Builder for PipelineBuilder<'a, T>
+impl<T> Builder for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type BuiltType = Pipeline<'a, T>;
+    type BuiltType = Pipeline<T>;
 
     fn build(&mut self) -> Self::BuiltType {
         Pipeline::<T>::new(&self.world, self.desc)
     }
 }
 
-impl<'a, T> FilterBuilderImpl for PipelineBuilder<'a, T>
+impl<T> FilterBuilderImpl for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_filter_mut(&mut self) -> &mut ecs_filter_desc_t {
@@ -203,9 +203,9 @@ where
     }
 }
 
-impl<'a, T> QueryBuilderImpl for PipelineBuilder<'a, T>
+impl<T> QueryBuilderImpl for PipelineBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_query_mut(&mut self) -> &mut ecs_query_desc_t {

--- a/flecs_ecs/src/addons/rules/rule.rs
+++ b/flecs_ecs/src/addons/rules/rule.rs
@@ -7,18 +7,18 @@ use flecs_ecs_sys::{
 
 use crate::core::{Entity, FilterView, IntoWorld, IterAPI, IterOperations, Iterable, World};
 
-pub struct Rule<'a, T>
+pub struct Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     rule: *mut ecs_rule_t,
     pub world: World,
-    _phantom: std::marker::PhantomData<&'a T>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> Deref for Rule<'a, T>
+impl<T> Deref for Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     type Target = *mut ecs_rule_t;
 
@@ -28,9 +28,9 @@ where
     }
 }
 
-impl<'a, T> Drop for Rule<'a, T>
+impl<T> Drop for Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn drop(&mut self) {
         if !self.rule.is_null() {
@@ -41,9 +41,9 @@ where
     }
 }
 
-impl<'a, T> Rule<'a, T>
+impl<T> Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new rule
     ///
@@ -117,7 +117,7 @@ where
     ///
     /// * C++ API: `rule_base::filter`
     #[doc(alias = "rule_base::filter")]
-    pub fn filter(&self) -> FilterView<'a, T> {
+    pub fn filter(&self) -> FilterView<T> {
         FilterView::new(&self.world, unsafe { ecs_rule_get_filter(self.rule) })
     }
 
@@ -144,9 +144,9 @@ where
     }
 }
 
-impl<'a, T> IterAPI<'a, T> for Rule<'a, T>
+impl<T> IterAPI<T> for Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn as_entity(&self) -> Entity {
         Entity::new_from_existing_raw(&self.world, unsafe {
@@ -155,18 +155,18 @@ where
     }
 }
 
-impl<'a, T> IntoWorld for Rule<'a, T>
+impl<T> IntoWorld for Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn world_ptr_mut(&self) -> *mut crate::core::WorldT {
         self.world.raw_world
     }
 }
 
-impl<'a, T> IterOperations for Rule<'a, T>
+impl<T> IterOperations for Rule<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn retrieve_iter(&self) -> crate::core::IterT {
         unsafe { ecs_rule_iter(self.world.raw_world, self.rule) }

--- a/flecs_ecs/src/addons/rules/rule_builder.rs
+++ b/flecs_ecs/src/addons/rules/rule_builder.rs
@@ -9,18 +9,18 @@ use crate::core::{
 
 use super::Rule;
 
-pub struct RuleBuilder<'a, T>
+pub struct RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    pub filter_builder: FilterBuilder<'a, T>,
+    pub filter_builder: FilterBuilder<T>,
 }
 
-impl<'a, T> Deref for RuleBuilder<'a, T>
+impl<T> Deref for RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type Target = FilterBuilder<'a, T>;
+    type Target = FilterBuilder<T>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -28,9 +28,9 @@ where
     }
 }
 
-impl<'a, T> RuleBuilder<'a, T>
+impl<T> RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new query builder
     ///
@@ -88,9 +88,9 @@ where
     }
 }
 
-impl<'a, T> Filterable for RuleBuilder<'a, T>
+impl<T> Filterable for RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn current_term(&mut self) -> &mut TermT {
         unsafe { &mut *self.filter_builder.term.term_ptr }
@@ -101,9 +101,9 @@ where
     }
 }
 
-impl<'a, T> FilterBuilderImpl for RuleBuilder<'a, T>
+impl<T> FilterBuilderImpl for RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_filter_mut(&mut self) -> &mut ecs_filter_desc_t {
@@ -121,9 +121,9 @@ where
     }
 }
 
-impl<'a, T> TermBuilder for RuleBuilder<'a, T>
+impl<T> TermBuilder for RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn world_ptr_mut(&self) -> *mut WorldT {
@@ -146,11 +146,11 @@ where
     }
 }
 
-impl<'a, T> Builder for RuleBuilder<'a, T>
+impl<T> Builder for RuleBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type BuiltType = Rule<'a, T>;
+    type BuiltType = Rule<T>;
 
     /// Build the `observer_builder` into an query
     ///

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -27,21 +27,21 @@ use crate::{
 
 use super::System;
 
-pub struct SystemBuilder<'a, T>
+pub struct SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    query_builder: QueryBuilder<'a, T>,
+    query_builder: QueryBuilder<T>,
     desc: ecs_system_desc_t,
     is_instanced: bool,
 }
 
 /// Deref to `QueryBuilder` to allow access to `QueryBuilder` methods without having to access `QueryBuilder` through `SystemBuilder`
-impl<'a, T> Deref for SystemBuilder<'a, T>
+impl<T> Deref for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type Target = QueryBuilder<'a, T>;
+    type Target = QueryBuilder<T>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -49,9 +49,9 @@ where
     }
 }
 
-impl<'a, T> DerefMut for SystemBuilder<'a, T>
+impl<T> DerefMut for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -59,9 +59,9 @@ where
     }
 }
 
-impl<'a, T> SystemBuilder<'a, T>
+impl<T> SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     pub fn new(world: &World) -> Self {
         let mut desc = Default::default();
@@ -319,9 +319,9 @@ where
     }
 }
 
-impl<'a, T> Filterable for SystemBuilder<'a, T>
+impl<T> Filterable for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn current_term(&mut self) -> &mut TermT {
         unsafe { &mut *self.filter_builder.term.term_ptr }
@@ -332,9 +332,9 @@ where
     }
 }
 
-impl<'a, T> FilterBuilderImpl for SystemBuilder<'a, T>
+impl<T> FilterBuilderImpl for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_filter_mut(&mut self) -> &mut ecs_filter_desc_t {
@@ -352,9 +352,9 @@ where
     }
 }
 
-impl<'a, T> TermBuilder for SystemBuilder<'a, T>
+impl<T> TermBuilder for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn world_ptr_mut(&self) -> *mut WorldT {
@@ -377,9 +377,9 @@ where
     }
 }
 
-impl<'a, T> QueryBuilderImpl for SystemBuilder<'a, T>
+impl<T> QueryBuilderImpl for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_query_mut(&mut self) -> &mut ecs_query_desc_t {
@@ -387,9 +387,9 @@ where
     }
 }
 
-impl<'a, T> Builder for SystemBuilder<'a, T>
+impl<T> Builder for SystemBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     type BuiltType = System;
 
@@ -404,4 +404,4 @@ where
     }
 }
 
-implement_reactor_api!(SystemBuilder<'a, T>);
+implement_reactor_api!(SystemBuilder<T>);

--- a/flecs_ecs/src/core/component_registration/registration_traits.rs
+++ b/flecs_ecs/src/core/component_registration/registration_traits.rs
@@ -40,7 +40,7 @@ pub trait ComponentType<T: ECSComponentType> {}
 /// If the world doesn't, this implies the component was registered by a different world.
 /// In such a case, the component is registered with the present world using the pre-existing ID.
 /// If the ID is already known, the trait takes care of the component registration and checks for consistency in the input.
-pub trait ComponentId: Sized + ComponentInfo {
+pub trait ComponentId: Sized + ComponentInfo + 'static {
     type UnderlyingType: ComponentId;
     type UnderlyingEnumType: ComponentId + CachedEnumData;
 
@@ -206,7 +206,7 @@ impl<T: ComponentInfo> ComponentInfo for &mut T {
     const IMPLS_DEFAULT: bool = T::IMPLS_DEFAULT;
 }
 
-impl<T: ComponentId> ComponentId for &T {
+impl<T: ComponentId> ComponentId for &'static T {
     fn __get_once_lock_data() -> &'static std::sync::OnceLock<flecs_ecs::core::IdComponent> {
         Self::UnderlyingType::__get_once_lock_data()
     }
@@ -216,7 +216,7 @@ impl<T: ComponentId> ComponentId for &T {
     type UnderlyingEnumType = T::UnderlyingEnumType;
 }
 
-impl<T: ComponentId> ComponentId for &mut T {
+impl<T: ComponentId> ComponentId for &'static mut T {
     fn __get_once_lock_data() -> &'static std::sync::OnceLock<flecs_ecs::core::IdComponent> {
         Self::UnderlyingType::__get_once_lock_data()
     }

--- a/flecs_ecs/src/core/filter.rs
+++ b/flecs_ecs/src/core/filter.rs
@@ -10,18 +10,18 @@ use super::{
     IterAPI, IterOperations,
 };
 
-pub struct FilterView<'a, T>
+pub struct FilterView<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     world: World,
     filter_ptr: *const FilterT,
-    _phantom: std::marker::PhantomData<&'a T>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> Clone for FilterView<'a, T>
+impl<T> Clone for FilterView<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn clone(&self) -> Self {
         Self {
@@ -32,9 +32,9 @@ where
     }
 }
 
-impl<'a, T> FilterView<'a, T>
+impl<T> FilterView<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new filter view
     ///
@@ -57,18 +57,18 @@ where
 }
 
 /// Filters are cheaper to create, but slower to iterate than queries.
-pub struct Filter<'a, T>
+pub struct Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     world: World,
-    _phantom: std::marker::PhantomData<&'a T>,
+    _phantom: std::marker::PhantomData<T>,
     filter: FilterT,
 }
 
-impl<'a, T> Filter<'a, T>
+impl<T> Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new filter
     ///
@@ -167,9 +167,9 @@ where
     }
 }
 
-impl<'a, T> Drop for Filter<'a, T>
+impl<T> Drop for Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn drop(&mut self) {
         // this is a hack to prevent ecs_filter_fini from freeing the memory of our stack allocated filter
@@ -181,12 +181,12 @@ where
     }
 }
 
-impl<'a, T> Clone for Filter<'a, T>
+impl<T> Clone for Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn clone(&self) -> Self {
-        let mut new_filter = Filter::<'a, T> {
+        let mut new_filter = Filter::<T> {
             world: self.world.clone(),
             _phantom: std::marker::PhantomData,
             filter: Default::default(),
@@ -197,18 +197,18 @@ where
     }
 }
 
-impl<'a, T> IntoWorld for Filter<'a, T>
+impl<T> IntoWorld for Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn world_ptr_mut(&self) -> *mut super::WorldT {
         self.world.raw_world
     }
 }
 
-impl<'a, T> IterOperations for Filter<'a, T>
+impl<T> IterOperations for Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn retrieve_iter(&self) -> super::IterT {
         unsafe { ecs_filter_iter(self.world.raw_world, &self.filter) }
@@ -227,18 +227,18 @@ where
     }
 }
 
-impl<'a, T> IntoWorld for FilterView<'a, T>
+impl<T> IntoWorld for FilterView<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn world_ptr_mut(&self) -> *mut super::WorldT {
         self.world.raw_world
     }
 }
 
-impl<'a, T> IterAPI<'a, T> for FilterView<'a, T>
+impl<T> IterAPI<T> for FilterView<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn as_entity(&self) -> Entity {
         Entity::new_from_existing_raw(&self.world, unsafe {
@@ -247,9 +247,9 @@ where
     }
 }
 
-impl<'a, T> IterOperations for FilterView<'a, T>
+impl<T> IterOperations for FilterView<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn retrieve_iter(&self) -> super::IterT {
         unsafe { ecs_filter_iter(self.world.raw_world, self.filter_ptr) }
@@ -268,9 +268,9 @@ where
     }
 }
 
-impl<'a, T> IterAPI<'a, T> for Filter<'a, T>
+impl<T> IterAPI<T> for Filter<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn as_entity(&self) -> Entity {
         Entity::new_from_existing_raw(&self.world, unsafe {

--- a/flecs_ecs/src/core/filter_builder.rs
+++ b/flecs_ecs/src/core/filter_builder.rs
@@ -25,21 +25,21 @@ use crate::{
 };
 
 /// Filters are cheaper to create, but slower to iterate than queries.
-pub struct FilterBuilder<'a, T>
+pub struct FilterBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     pub desc: ecs_filter_desc_t,
     expr_count: i32,
     pub(crate) term: Term,
     pub world: World,
     pub next_term_index: i32,
-    _phantom: std::marker::PhantomData<&'a T>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> FilterBuilder<'a, T>
+impl<T> FilterBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new filter builder.
     ///
@@ -135,9 +135,9 @@ where
     }
 }
 
-impl<'a, T> Filterable for FilterBuilder<'a, T>
+impl<T> Filterable for FilterBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn current_term(&mut self) -> &mut TermT {
         unsafe { &mut *self.term.term_ptr }
@@ -148,9 +148,9 @@ where
     }
 }
 
-impl<'a, T> FilterBuilderImpl for FilterBuilder<'a, T>
+impl<T> FilterBuilderImpl for FilterBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_filter_mut(&mut self) -> &mut ecs_filter_desc_t {
@@ -168,9 +168,9 @@ where
     }
 }
 
-impl<'a, T> TermBuilder for FilterBuilder<'a, T>
+impl<T> TermBuilder for FilterBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn world_ptr_mut(&self) -> *mut WorldT {
@@ -193,15 +193,15 @@ where
     }
 }
 
-impl<'a, T> Builder for FilterBuilder<'a, T>
+impl<T> Builder for FilterBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type BuiltType = Filter<'a, T>;
+    type BuiltType = Filter<T>;
 
     #[inline]
     fn build(&mut self) -> Self::BuiltType {
-        Filter::<'a, T>::new_from_desc(&self.world, &mut self.desc as *mut _)
+        Filter::<T>::new_from_desc(&self.world, &mut self.desc as *mut _)
     }
 }
 

--- a/flecs_ecs/src/core/iter_iterable.rs
+++ b/flecs_ecs/src/core/iter_iterable.rs
@@ -13,18 +13,18 @@ use super::{
 use crate::core::FlecsErrorCode;
 use crate::ecs_assert;
 
-pub struct IterIterable<'a, T>
+pub struct IterIterable<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     iter: IterT,
     iter_next: unsafe extern "C" fn(*mut IterT) -> bool,
-    _phantom: std::marker::PhantomData<&'a T>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> IterIterable<'a, T>
+impl<T> IterIterable<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     pub fn new(iter: IterT, iter_next: unsafe extern "C" fn(*mut IterT) -> bool) -> Self {
         Self {
@@ -124,9 +124,9 @@ where
     }
 }
 
-impl<'a, T> IterOperations for IterIterable<'a, T>
+impl<T> IterOperations for IterIterable<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn retrieve_iter(&self) -> IterT {
         self.iter
@@ -145,9 +145,9 @@ where
     }
 }
 
-impl<'a, T> IterAPI<'a, T> for IterIterable<'a, T>
+impl<T> IterAPI<T> for IterIterable<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn as_entity(&self) -> Entity {
         Entity::new_from_existing_raw(self.iter.real_world, unsafe {
@@ -156,9 +156,9 @@ where
     }
 }
 
-impl<'a, T> IntoWorld for IterIterable<'a, T>
+impl<T> IntoWorld for IterIterable<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn world_ptr_mut(&self) -> *mut WorldT {
         self.iter.real_world

--- a/flecs_ecs/src/core/iterable.rs
+++ b/flecs_ecs/src/core/iterable.rs
@@ -633,7 +633,7 @@ macro_rules! impl_iterable {
                     components[index as usize] =
                     unsafe { ecs_field::<$t::OnlyType>(it, index + 1) as *mut u8 };
                     is_ref[index as usize] = if !it.sources.is_null() {
-                        unsafe { *it.sources.add(0) != 0 }
+                        unsafe { *it.sources.add(index as usize) != 0 }
                     } else {
                         false
                     };

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -21,22 +21,22 @@ use super::{
     Builder, IntoEntityId, ReactorAPI, Term, WorldT,
 };
 
-pub struct ObserverBuilder<'a, T>
+pub struct ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    filter_builder: FilterBuilder<'a, T>,
+    filter_builder: FilterBuilder<T>,
     desc: ecs_observer_desc_t,
     event_count: i32,
     is_instanced: bool,
 }
 
 /// Deref to `FilterBuilder` to allow access to `FilterBuilder` methods without having to access `FilterBuilder` through `ObserverBuilder`
-impl<'a, T> Deref for ObserverBuilder<'a, T>
+impl<T> Deref for ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type Target = FilterBuilder<'a, T>;
+    type Target = FilterBuilder<T>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -44,9 +44,9 @@ where
     }
 }
 
-impl<'a, T> ObserverBuilder<'a, T>
+impl<T> ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new observer builder
     ///
@@ -200,9 +200,9 @@ where
     }
 }
 
-impl<'a, T> Filterable for ObserverBuilder<'a, T>
+impl<T> Filterable for ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn current_term(&mut self) -> &mut TermT {
         unsafe { &mut *self.filter_builder.term.term_ptr }
@@ -213,9 +213,9 @@ where
     }
 }
 
-impl<'a, T> FilterBuilderImpl for ObserverBuilder<'a, T>
+impl<T> FilterBuilderImpl for ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_filter_mut(&mut self) -> &mut ecs_filter_desc_t {
@@ -233,9 +233,9 @@ where
     }
 }
 
-impl<'a, T> TermBuilder for ObserverBuilder<'a, T>
+impl<T> TermBuilder for ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn world_ptr_mut(&self) -> *mut WorldT {
@@ -258,9 +258,9 @@ where
     }
 }
 
-impl<'a, T> Builder for ObserverBuilder<'a, T>
+impl<T> Builder for ObserverBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     type BuiltType = Observer;
 
@@ -275,4 +275,4 @@ where
     }
 }
 
-implement_reactor_api!(ObserverBuilder<'a, T>);
+implement_reactor_api!(ObserverBuilder<T>);

--- a/flecs_ecs/src/core/query.rs
+++ b/flecs_ecs/src/core/query.rs
@@ -20,18 +20,18 @@ use super::{
 
 /// Cached query implementation. Fast to iterate, but slower to create than `Filters`
 #[derive(Clone)]
-pub struct Query<'a, T>
+pub struct Query<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     pub world: World,
     pub query: *mut QueryT,
-    _phantom: std::marker::PhantomData<&'a T>,
+    _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T> IterOperations for Query<'a, T>
+impl<T> IterOperations for Query<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline(always)]
     fn retrieve_iter(&self) -> IterT {
@@ -52,9 +52,9 @@ where
     }
 }
 
-impl<'a, T> IterAPI<'a, T> for Query<'a, T>
+impl<T> IterAPI<T> for Query<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn as_entity(&self) -> Entity {
         Entity::new_from_existing_raw(self.world.raw_world, unsafe {
@@ -63,9 +63,9 @@ where
     }
 }
 
-impl<'a, T> Query<'a, T>
+impl<T> Query<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new query
     ///
@@ -263,14 +263,14 @@ where
     ///
     /// * C++ API: `query_base::filter`
     #[doc(alias = "query_base::filter")]
-    pub fn filter(&self) -> FilterView<'a, T> {
+    pub fn filter(&self) -> FilterView<T> {
         FilterView::<T>::new(&self.world, unsafe { ecs_query_get_filter(self.query) })
     }
 }
 
-impl<'a, T> Drop for Query<'a, T>
+impl<T> Drop for Query<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Destroy a query. This operation destroys a query and its resources.
     /// If the query is used as the parent of subqueries, those subqueries will be orphaned

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -121,11 +121,10 @@ where
     /// * C++ API: `query_builder_i::query_builder_i`
     #[doc(alias = "query_builder_i::query_builder_i")]
     pub fn new_from_desc(world: &World, desc: &mut ecs_query_desc_t) -> Self {
-        let obj = Self {
+        Self {
             desc: *desc,
             filter_builder: FilterBuilder::new_from_desc(world, &mut desc.filter, 0),
-        };
-        obj
+        }
     }
 
     /// Create a new query builder from an existing descriptor with a term index

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -24,19 +24,19 @@ use super::{
 };
 
 /// Fast to iterate, but slower to create than Filter
-pub struct QueryBuilder<'a, T>
+pub struct QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    pub filter_builder: FilterBuilder<'a, T>,
+    pub filter_builder: FilterBuilder<T>,
     pub desc: ecs_query_desc_t,
 }
 
-impl<'a, T> Deref for QueryBuilder<'a, T>
+impl<T> Deref for QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type Target = FilterBuilder<'a, T>;
+    type Target = FilterBuilder<T>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -44,9 +44,9 @@ where
     }
 }
 
-impl<'a, T> QueryBuilder<'a, T>
+impl<T> QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Create a new query builder
     ///
@@ -163,9 +163,9 @@ where
     }
 }
 
-impl<'a, T> Filterable for QueryBuilder<'a, T>
+impl<T> Filterable for QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     fn current_term(&mut self) -> &mut TermT {
         unsafe { &mut *self.filter_builder.term.term_ptr }
@@ -176,9 +176,9 @@ where
     }
 }
 
-impl<'a, T> FilterBuilderImpl for QueryBuilder<'a, T>
+impl<T> FilterBuilderImpl for QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_filter_mut(&mut self) -> &mut ecs_filter_desc_t {
@@ -196,9 +196,9 @@ where
     }
 }
 
-impl<'a, T> TermBuilder for QueryBuilder<'a, T>
+impl<T> TermBuilder for QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn world_ptr_mut(&self) -> *mut WorldT {
@@ -221,11 +221,11 @@ where
     }
 }
 
-impl<'a, T> Builder for QueryBuilder<'a, T>
+impl<T> Builder for QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
-    type BuiltType = Query<'a, T>;
+    type BuiltType = Query<T>;
 
     /// Build the `observer_builder` into an query
     ///
@@ -235,7 +235,7 @@ where
     #[doc(alias = "node_builder::build")]
     fn build(&mut self) -> Self::BuiltType {
         let world = &self.filter_builder.world;
-        Query::<'a, T>::new_from_desc(world, &mut self.desc)
+        Query::<T>::new_from_desc(world, &mut self.desc)
     }
 }
 
@@ -457,16 +457,16 @@ pub trait QueryBuilderImpl: FilterBuilderImpl {
     ///
     /// * C++ API: `query_builder_i::observable`
     #[doc(alias = "query_builder_i::observable")]
-    fn observable<'a, T: Iterable<'a>>(&mut self, parent: &Query<'a, T>) -> &mut Self {
+    fn observable<T: Iterable>(&mut self, parent: &Query<T>) -> &mut Self {
         let desc = self.desc_query_mut();
         desc.parent = parent.query;
         self
     }
 }
 
-impl<'a, T> QueryBuilderImpl for QueryBuilder<'a, T>
+impl<T> QueryBuilderImpl for QueryBuilder<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     fn desc_query_mut(&mut self) -> &mut ecs_query_desc_t {

--- a/flecs_ecs/src/core/utility/traits/into_world.rs
+++ b/flecs_ecs/src/core/utility/traits/into_world.rs
@@ -98,9 +98,9 @@ where
     }
 }
 
-impl<'a, T> IntoWorld for Query<'a, T>
+impl<T> IntoWorld for Query<T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     #[inline]
     #[doc(hidden)]

--- a/flecs_ecs/src/core/utility/traits/iter.rs
+++ b/flecs_ecs/src/core/utility/traits/iter.rs
@@ -24,9 +24,9 @@ pub trait IterOperations {
     fn filter_ptr(&self) -> *const FilterT;
 }
 
-pub trait IterAPI<'a, T>: IterOperations + IntoWorld
+pub trait IterAPI<T>: IterOperations + IntoWorld
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     // TODO once we have tests in place, I will split this functionality up into multiple functions, which should give a small performance boost
     // by caching if the query has used a "is_ref" operation.
@@ -43,7 +43,7 @@ where
     ///
     /// * C++ API: `iterable::each`
     #[doc(alias = "iterable::each")]
-    fn each(&self, mut func: impl FnMut(T::TupleType)) {
+    fn each(&self, mut func: impl FnMut(T::TupleType<'_>)) {
         unsafe {
             let mut iter = self.retrieve_iter();
 
@@ -74,7 +74,7 @@ where
     ///
     /// * C++ API: `iterable::each`
     #[doc(alias = "iterable::each")]
-    fn each_entity(&self, mut func: impl FnMut(&mut Entity, T::TupleType)) {
+    fn each_entity(&self, mut func: impl FnMut(&mut Entity, T::TupleType<'_>)) {
         unsafe {
             let mut iter = self.retrieve_iter();
             let world = self.world_ptr_mut();
@@ -107,7 +107,7 @@ where
         }
     }
 
-    fn each_iter(&self, mut func: impl FnMut(&mut Iter, usize, T::TupleType)) {
+    fn each_iter(&self, mut func: impl FnMut(&mut Iter, usize, T::TupleType<'_>)) {
         unsafe {
             let mut iter = self.retrieve_iter();
             let world = self.world_ptr_mut();
@@ -153,7 +153,7 @@ where
     ///
     /// * C++ API: `find_delegate::invoke_callback`
     #[doc(alias = "find_delegate::invoke_callback")]
-    fn find(&self, mut func: impl FnMut(T::TupleType) -> bool) -> Option<Entity> {
+    fn find(&self, mut func: impl FnMut(T::TupleType<'_>) -> bool) -> Option<Entity> {
         unsafe {
             let mut iter = self.retrieve_iter();
             let mut entity: Option<Entity> = None;
@@ -200,7 +200,7 @@ where
     #[doc(alias = "find_delegate::invoke_callback")]
     fn find_entity(
         &self,
-        mut func: impl FnMut(&mut Entity, T::TupleType) -> bool,
+        mut func: impl FnMut(&mut Entity, T::TupleType<'_>) -> bool,
     ) -> Option<Entity> {
         unsafe {
             let mut iter = self.retrieve_iter();
@@ -248,7 +248,7 @@ where
     #[doc(alias = "find_delegate::invoke_callback")]
     fn find_iter(
         &self,
-        mut func: impl FnMut(&mut Iter, usize, T::TupleType) -> bool,
+        mut func: impl FnMut(&mut Iter, usize, T::TupleType<'_>) -> bool,
     ) -> Option<Entity> {
         unsafe {
             let mut iter = self.retrieve_iter();
@@ -299,7 +299,7 @@ where
     ///
     /// * C++ API: `iterable::iter`
     #[doc(alias = "iterable::iter")]
-    fn iter(&self, mut func: impl FnMut(&mut Iter, T::TupleSliceType)) {
+    fn iter(&self, mut func: impl FnMut(&mut Iter, T::TupleSliceType<'_>)) {
         unsafe {
             let mut iter = self.retrieve_iter();
             let world = self.world_ptr_mut();
@@ -457,7 +457,7 @@ where
         rust_string
     }
 
-    fn iterable(&self) -> IterIterable<'a, T> {
+    fn iterable(&self) -> IterIterable<T> {
         IterIterable::new(self.retrieve_iter(), self.iter_next_func())
     }
 

--- a/flecs_ecs/src/core/utility/traits/mod.rs
+++ b/flecs_ecs/src/core/utility/traits/mod.rs
@@ -28,7 +28,7 @@ pub mod private {
     #[doc(hidden)]
     pub trait internal_ReactorAPI<'a, T>
     where
-        T: Iterable<'a>,
+        T: Iterable,
     {
         fn set_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self;
 
@@ -49,7 +49,7 @@ pub mod private {
         /// * C++ API: `iter_invoker::invoke_callback`
         unsafe extern "C" fn run_each<Func>(iter: *mut IterT)
         where
-            Func: FnMut(T::TupleType),
+            Func: FnMut(T::TupleType<'_>),
         {
             let ctx: *mut ObserverSystemBindingCtx = (*iter).binding_ctx as *mut _;
             let each = (*ctx).each.unwrap();
@@ -86,7 +86,7 @@ pub mod private {
         #[doc(alias = "iter_invoker::invoke_callback")]
         unsafe extern "C" fn run_each_entity<Func>(iter: *mut IterT)
         where
-            Func: FnMut(&mut Entity, T::TupleType),
+            Func: FnMut(&mut Entity, T::TupleType<'_>),
         {
             let ctx: *mut ObserverSystemBindingCtx = (*iter).binding_ctx as *mut _;
             let each_entity = (*ctx).each_entity.unwrap();
@@ -125,7 +125,7 @@ pub mod private {
         #[doc(alias = "iter_invoker::invoke_callback")]
         unsafe extern "C" fn run_each_iter<Func>(iter: *mut IterT)
         where
-            Func: FnMut(&mut Iter, usize, T::TupleType),
+            Func: FnMut(&mut Iter, usize, T::TupleType<'_>),
         {
             let ctx: *mut ObserverSystemBindingCtx = (*iter).binding_ctx as *mut _;
             let each_iter = (*ctx).each_iter.unwrap();
@@ -200,7 +200,7 @@ pub mod private {
         #[doc(alias = "iter_invoker::invoke_callback")]
         unsafe extern "C" fn run_iter<Func>(iter: *mut IterT)
         where
-            Func: FnMut(&mut Iter, T::TupleSliceType),
+            Func: FnMut(&mut Iter, T::TupleSliceType<'_>),
         {
             let ctx: *mut ObserverSystemBindingCtx = (*iter).binding_ctx as *mut _;
             let iter_func = (*ctx).iter.unwrap();
@@ -226,23 +226,23 @@ pub mod private {
         // free functions
 
         extern "C" fn on_free_each(ptr: *mut c_void) {
-            let ptr_func: *mut fn(T::TupleType) = ptr as *mut fn(T::TupleType);
+            let ptr_func: *mut fn(T::TupleType<'_>) = ptr as *mut fn(T::TupleType<'_>);
             unsafe {
                 ptr::drop_in_place(ptr_func);
             }
         }
 
         extern "C" fn on_free_each_entity(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&mut Entity, T::TupleType) =
-                ptr as *mut fn(&mut Entity, T::TupleType);
+            let ptr_func: *mut fn(&mut Entity, T::TupleType<'_>) =
+                ptr as *mut fn(&mut Entity, T::TupleType<'_>);
             unsafe {
                 ptr::drop_in_place(ptr_func);
             }
         }
 
         extern "C" fn on_free_each_iter(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&mut Iter, usize, T::TupleType) =
-                ptr as *mut fn(&mut Iter, usize, T::TupleType);
+            let ptr_func: *mut fn(&mut Iter, usize, T::TupleType<'_>) =
+                ptr as *mut fn(&mut Iter, usize, T::TupleType<'_>);
             unsafe {
                 ptr::drop_in_place(ptr_func);
             }
@@ -256,8 +256,8 @@ pub mod private {
         }
 
         extern "C" fn on_free_iter(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&Iter, T::TupleSliceType) =
-                ptr as *mut fn(&Iter, T::TupleSliceType);
+            let ptr_func: *mut fn(&Iter, T::TupleSliceType<'_>) =
+                ptr as *mut fn(&Iter, T::TupleSliceType<'_>);
             unsafe {
                 ptr::drop_in_place(ptr_func);
             }

--- a/flecs_ecs/src/core/utility/traits/reactor.rs
+++ b/flecs_ecs/src/core/utility/traits/reactor.rs
@@ -8,7 +8,7 @@ use super::private;
 
 pub trait ReactorAPI<'a, T>: Builder + private::internal_ReactorAPI<'a, T>
 where
-    T: Iterable<'a>,
+    T: Iterable,
 {
     /// Set action / ctx
     ///
@@ -37,7 +37,7 @@ where
 
     fn on_each<Func>(&mut self, func: Func) -> <Self as builder::Builder>::BuiltType
     where
-        Func: FnMut(T::TupleType),
+        Func: FnMut(T::TupleType<'_>),
     {
         let binding_ctx = self.get_binding_context();
 
@@ -56,7 +56,7 @@ where
 
     fn on_each_entity<Func>(&mut self, func: Func) -> <Self as builder::Builder>::BuiltType
     where
-        Func: FnMut(&mut Entity, T::TupleType),
+        Func: FnMut(&mut Entity, T::TupleType<'_>),
     {
         let binding_ctx = self.get_binding_context();
 
@@ -77,7 +77,7 @@ where
 
     fn on_each_iter<Func>(&mut self, func: Func) -> <Self as builder::Builder>::BuiltType
     where
-        Func: FnMut(&mut Iter, usize, T::TupleType),
+        Func: FnMut(&mut Iter, usize, T::TupleType<'_>),
     {
         let binding_ctx = self.get_binding_context();
 
@@ -113,7 +113,7 @@ where
 
     fn on_iter<Func>(&mut self, func: Func) -> <Self as builder::Builder>::BuiltType
     where
-        Func: FnMut(&mut Iter, T::TupleSliceType),
+        Func: FnMut(&mut Iter, T::TupleSliceType<'_>),
     {
         let binding_ctx = self.get_binding_context();
 
@@ -135,7 +135,7 @@ macro_rules! implement_reactor_api {
     ($type:ty) => {
         impl<'a, T> internal_ReactorAPI<'a, T> for $type
         where
-            T: Iterable<'a>,
+            T: Iterable,
         {
             fn set_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
                 self.desc.binding_ctx = binding_ctx;
@@ -164,7 +164,7 @@ macro_rules! implement_reactor_api {
 
         impl<'a, T> ReactorAPI<'a, T> for $type
         where
-            T: Iterable<'a>,
+            T: Iterable,
         {
             fn set_run_callback(&mut self, callback: ecs_iter_action_t) -> &mut Self {
                 self.desc.run = callback;

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -3067,11 +3067,11 @@ impl World {
     ///
     /// * C++ API: `world::observer`
     #[doc(alias = "world::observer")]
-    pub fn observer_builder<'a, Components>(&self) -> ObserverBuilder<'a, Components>
+    pub fn observer_builder<Components>(&self) -> ObserverBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        ObserverBuilder::<'a, Components>::new(self)
+        ObserverBuilder::<Components>::new(self)
     }
 
     /// Create a new named observer.
@@ -3092,14 +3092,11 @@ impl World {
     ///
     /// * C++ API: `world::observer`
     #[doc(alias = "world::observer")]
-    pub fn observer_builder_named<'a, Components>(
-        &self,
-        name: &CStr,
-    ) -> ObserverBuilder<'a, Components>
+    pub fn observer_builder_named<Components>(&self, name: &CStr) -> ObserverBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        ObserverBuilder::<'a, Components>::new_named(self, name)
+        ObserverBuilder::<Components>::new_named(self, name)
     }
 }
 
@@ -3119,11 +3116,11 @@ impl World {
     ///
     /// * C++ API: `world::filter`
     #[doc(alias = "world::filter")]
-    pub fn filter<'a, Components>(&self) -> Filter<'a, Components>
+    pub fn filter<Components>(&self) -> Filter<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        Filter::<'a, Components>::new(self)
+        Filter::<Components>::new(self)
     }
 
     /// Create a new named filter.
@@ -3144,11 +3141,11 @@ impl World {
     ///
     /// * C++ API: `world::filter`
     #[doc(alias = "world::filter")]
-    pub fn filter_named<'a, Components>(&self, name: &CStr) -> Filter<'a, Components>
+    pub fn filter_named<Components>(&self, name: &CStr) -> Filter<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        FilterBuilder::<'a, Components>::new_named(self, name).build()
+        FilterBuilder::<Components>::new_named(self, name).build()
     }
 
     /// Create a `filter_builder`
@@ -3165,11 +3162,11 @@ impl World {
     ///
     /// * C++ API: `world::filter_builder`
     #[doc(alias = "world::filter_builder")]
-    pub fn filter_builder<'a, Components>(&self) -> FilterBuilder<'a, Components>
+    pub fn filter_builder<Components>(&self) -> FilterBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        FilterBuilder::<'a, Components>::new(self)
+        FilterBuilder::<Components>::new(self)
     }
 
     /// Create a new named `filter_builder`.
@@ -3190,33 +3187,33 @@ impl World {
     ///
     /// * C++ API: `world::filter_builder`
     #[doc(alias = "world::filter_builder")]
-    pub fn filter_builder_named<'a, Components>(&self, name: &CStr) -> FilterBuilder<'a, Components>
+    pub fn filter_builder_named<Components>(&self, name: &CStr) -> FilterBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        FilterBuilder::<'a, Components>::new_named(self, name)
+        FilterBuilder::<Components>::new_named(self, name)
     }
 
-    pub fn each<'a, Components>(
+    pub fn each<Components>(
         &self,
-        func: impl FnMut(Components::TupleType),
-    ) -> Filter<'a, Components>
+        func: impl FnMut(Components::TupleType<'_>),
+    ) -> Filter<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        let filter = Filter::<'a, Components>::new(self);
+        let filter = Filter::<Components>::new(self);
         filter.each(func);
         filter
     }
 
-    pub fn each_entity<'a, Components>(
+    pub fn each_entity<Components>(
         &self,
-        func: impl FnMut(&mut Entity, Components::TupleType),
-    ) -> Filter<'a, Components>
+        func: impl FnMut(&mut Entity, Components::TupleType<'_>),
+    ) -> Filter<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        let filter = Filter::<'a, Components>::new(self);
+        let filter = Filter::<Components>::new(self);
         filter.each_entity(func);
         filter
     }
@@ -3238,11 +3235,11 @@ impl World {
     ///
     /// * C++ API: `world::query`
     #[doc(alias = "world::query")]
-    pub fn query<'a, Components>(&self) -> Query<'a, Components>
+    pub fn query<Components>(&self) -> Query<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        Query::<'a, Components>::new(self)
+        Query::<Components>::new(self)
     }
 
     /// Create a new named query.
@@ -3263,11 +3260,11 @@ impl World {
     ///
     /// * C++ API: `world::query`
     #[doc(alias = "world::query")]
-    pub fn query_named<'a, Components>(&self, name: &CStr) -> Query<'a, Components>
+    pub fn query_named<Components>(&self, name: &CStr) -> Query<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        QueryBuilder::<'a, Components>::new_named(self, name).build()
+        QueryBuilder::<Components>::new_named(self, name).build()
     }
 
     /// Create a new query builder.
@@ -3284,11 +3281,11 @@ impl World {
     ///
     /// * C++ API: `world::query_builder`
     #[doc(alias = "world::query_builder")]
-    pub fn query_builder<'a, Components>(&self) -> QueryBuilder<'a, Components>
+    pub fn query_builder<Components>(&self) -> QueryBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        QueryBuilder::<'a, Components>::new(self)
+        QueryBuilder::<Components>::new(self)
     }
 
     /// Create a new named query builder.
@@ -3309,11 +3306,11 @@ impl World {
     ///
     /// * C++ API: `world::query_builder`
     #[doc(alias = "world::query_builder")]
-    pub fn query_builder_named<'a, Components>(&self, name: &CStr) -> QueryBuilder<'a, Components>
+    pub fn query_builder_named<Components>(&self, name: &CStr) -> QueryBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        QueryBuilder::<'a, Components>::new_named(self, name)
+        QueryBuilder::<Components>::new_named(self, name)
     }
 }
 
@@ -3348,11 +3345,11 @@ impl World {
     ///
     /// * C++ API: `world::system_builder`
     #[doc(alias = "world::system_builder")]
-    pub fn system_builder<'a, Components>(&self) -> SystemBuilder<'a, Components>
+    pub fn system_builder<Components>(&self) -> SystemBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        SystemBuilder::<'a, Components>::new(self)
+        SystemBuilder::<Components>::new(self)
     }
 
     /// Creates a new named `SystemBuilder` instance.
@@ -3370,11 +3367,11 @@ impl World {
     ///
     /// * C++ API: `world::system_builder`
     #[doc(alias = "world::system_builder")]
-    pub fn system_builder_named<'a, Components>(&self, name: &CStr) -> SystemBuilder<'a, Components>
+    pub fn system_builder_named<Components>(&self, name: &CStr) -> SystemBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        SystemBuilder::<'a, Components>::new_named(self, name)
+        SystemBuilder::<Components>::new_named(self, name)
     }
 
     /// Creates a `SystemBuilder` from a system description.
@@ -3392,14 +3389,14 @@ impl World {
     ///
     /// * C++ API: `world::system_builder`
     #[doc(alias = "world::system_builder")]
-    pub fn system_builder_from_desc<'a, Components>(
+    pub fn system_builder_from_desc<Components>(
         &self,
         desc: ecs_system_desc_t,
-    ) -> SystemBuilder<'a, Components>
+    ) -> SystemBuilder<Components>
     where
-        Components: Iterable<'a>,
+        Components: Iterable,
     {
-        SystemBuilder::<'a, Components>::new_from_desc(self, desc)
+        SystemBuilder::<Components>::new_from_desc(self, desc)
     }
 }
 
@@ -3889,11 +3886,11 @@ impl World {
     /// * C++ API: `world::rule`
     #[doc(alias = "world::rule")]
     #[inline(always)]
-    pub fn rule<'a, T>(&self) -> crate::addons::rules::Rule<'a, T>
+    pub fn rule<T>(&self) -> crate::addons::rules::Rule<T>
     where
-        T: Iterable<'a>,
+        T: Iterable,
     {
-        crate::addons::rules::RuleBuilder::<'a, T>::new(self).build()
+        crate::addons::rules::RuleBuilder::<T>::new(self).build()
     }
 
     /// Create a new named rule.
@@ -3911,11 +3908,11 @@ impl World {
     /// * C++ API: `world::rule`
     #[doc(alias = "world::rule")]
     #[inline(always)]
-    pub fn rule_named<'a, T>(&self, name: &CStr) -> crate::addons::rules::Rule<'a, T>
+    pub fn rule_named<T>(&self, name: &CStr) -> crate::addons::rules::Rule<T>
     where
-        T: Iterable<'a>,
+        T: Iterable,
     {
-        crate::addons::rules::RuleBuilder::<'a, T>::new_named(self, name).build()
+        crate::addons::rules::RuleBuilder::<T>::new_named(self, name).build()
     }
 
     /// Create a new rule builder.
@@ -3929,11 +3926,11 @@ impl World {
     /// * C++ API: `world::rule_builder`
     #[doc(alias = "world::rule_builder")]
     #[inline(always)]
-    pub fn rule_builder<'a, T>(&self) -> crate::addons::rules::RuleBuilder<'a, T>
+    pub fn rule_builder<T>(&self) -> crate::addons::rules::RuleBuilder<T>
     where
-        T: Iterable<'a>,
+        T: Iterable,
     {
-        crate::addons::rules::RuleBuilder::<'a, T>::new(self)
+        crate::addons::rules::RuleBuilder::<T>::new(self)
     }
 
     /// Create a new named rule builder.
@@ -3951,10 +3948,10 @@ impl World {
     /// * C++ API: `world::rule_builder`
     #[doc(alias = "world::rule_builder")]
     #[inline(always)]
-    pub fn rule_builder_named<'a, T>(&self, name: &CStr) -> crate::addons::rules::RuleBuilder<'a, T>
+    pub fn rule_builder_named<T>(&self, name: &CStr) -> crate::addons::rules::RuleBuilder<T>
     where
-        T: Iterable<'a>,
+        T: Iterable,
     {
-        crate::addons::rules::RuleBuilder::<'a, T>::new_named(self, name)
+        crate::addons::rules::RuleBuilder::<T>::new_named(self, name)
     }
 }

--- a/flecs_ecs/tests/entity_test.rs
+++ b/flecs_ecs/tests/entity_test.rs
@@ -1414,33 +1414,6 @@ fn entity_entity_to_entity_view() {
     assert_eq!(p.y, 20);
 }
 
-const DEFAULTENTITY: flecs_ecs::core::Entity = flecs_ecs::core::Entity::new_null();
-
-#[derive(Debug, flecs_ecs_derive::Component)]
-struct ParentRef<'a> {
-    _parent: &'a flecs_ecs::core::Entity,
-}
-
-impl Default for ParentRef<'_> {
-    fn default() -> Self {
-        ParentRef {
-            _parent: &DEFAULTENTITY,
-        }
-    }
-}
-
-impl<'a> flecs_ecs::core::component_registration::registration_traits::ComponentId
-    for ParentRef<'a>
-{
-    type UnderlyingType = Self;
-    type UnderlyingEnumType = flecs_ecs::core::component_registration::NoneEnum;
-    fn __get_once_lock_data() -> &'static std::sync::OnceLock<flecs_ecs::core::IdComponent> {
-        static ONCE_LOCK: std::sync::OnceLock<flecs_ecs::core::IdComponent> =
-            std::sync::OnceLock::new();
-        &ONCE_LOCK
-    }
-}
-
 #[test]
 fn entity_entity_view_to_entity_world() {
     let world = World::new();


### PR DESCRIPTION
Trap the lifetime of component references to within the closure they are borrowed in.

Remove ineffective lifetimes from unrelated structs.