### PR TITLE
Remove coredoc references.

### DIFF
--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -91,9 +91,6 @@ flecs_json = ["flecs_ecs_sys/flecs_json", "flecs_expr"]
 # Document entities & components
 flecs_doc = ["flecs_ecs_sys/flecs_doc", "flecs_module"]
 
-# Documentation for core entities & components
-flecs_coredoc = ["flecs_ecs_sys/flecs_coredoc","flecs_doc", "flecs_meta"]
-
 # When enabled ECS provides more detailed logs
 flecs_log = ["flecs_ecs_sys/flecs_log"]
 
@@ -139,7 +136,6 @@ default = [
     "flecs_expr",
     "flecs_json",
     "flecs_doc",
-    "flecs_coredoc",
     "flecs_log",
     "flecs_app",
     "flecs_os_api_impl",

--- a/flecs_ecs_sys/Cargo.toml
+++ b/flecs_ecs_sys/Cargo.toml
@@ -103,9 +103,6 @@ flecs_json = ["flecs_expr"]
 # Document entities & components
 flecs_doc = ["flecs_module"]
 
-# Documentation for core entities & components
-flecs_coredoc = ["flecs_doc", "flecs_meta"]
-
 # When enabled ECS provides more detailed logs
 flecs_log = []
 

--- a/flecs_ecs_sys/build.rs
+++ b/flecs_ecs_sys/build.rs
@@ -153,11 +153,6 @@ fn generate_bindings() {
         bindings = bindings.clang_arg("-DFLECS_DOC");
     }
 
-    #[cfg(feature = "flecs_coredoc")]
-    {
-        bindings = bindings.clang_arg("-DFLECS_COREDOC");
-    }
-
     #[cfg(feature = "flecs_log")]
     {
         bindings = bindings.clang_arg("-DFLECS_LOG");
@@ -266,9 +261,6 @@ fn main() {
 
         #[cfg(feature = "flecs_doc")]
         build.define("FLECS_DOC", None);
-
-        #[cfg(feature = "flecs_coredoc")]
-        build.define("FLECS_COREDOC", None);
 
         #[cfg(feature = "flecs_log")]
         build.define("FLECS_LOG", None);


### PR DESCRIPTION
This was removed from flecs (merged with doc, meta) in https://github.com/SanderMertens/flecs/commit/bc933e6dae367c8e7993673dfc8d49990b4dd3bc