### PR TITLE
Change single world feature into multi-world feature. Allow opting into multi-world support.

### DIFF
--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -55,13 +55,13 @@ flecs_disable_build_c = ["flecs_ecs_sys/disable_build_c"]
 # Flecs feature flags
 ######################
 
-# indicate that the flecs library is meant to be used in a singleworld application
-# this will enable some optimization that would otherwise not be possible
-# in Flecs C++ it's necessary for components to be registered manually before being used in multithreaded systems
+# indicate that the flecs library is meant to be used in a multi-world application
+# this will disable some optimizations.
+# In Flecs C++ it's necessary for components to be registered manually before being used in multithreaded systems
 # this is not necessary in Rust and is considered multithreaded safe for single world applications.
-# If you intent to have multiple worlds, you should not enable this feature and register components manually
+# If you intend to have multiple worlds, you should enable this feature and register components manually
 # if the intent is to share components between worlds, like in C++. In the future this limitation might be mitigated.
-flecs_single_world_application = []
+flecs_multi_world_application = []
 
 # Module support
 flecs_module = ["flecs_ecs_sys/flecs_module"]
@@ -133,7 +133,6 @@ flecs_rest = ["flecs_ecs_sys/flecs_rest", "flecs_http", "flecs_json", "flecs_rul
 flecs_journal = ["flecs_ecs_sys/flecs_journal","flecs_log"]
 
 default = [
-    "flecs_single_world_application",
     "flecs_regenerate_binding_c",
     "flecs_module",
     "flecs_parser",

--- a/flecs_ecs/benches/common.rs
+++ b/flecs_ecs/benches/common.rs
@@ -98,11 +98,11 @@ pub mod common {
     /// This function is called at the end of each iteration to do this reset.
     #[inline(always)]
     pub fn reset_component<T: ComponentId>() {
-        #[cfg(feature = "flecs_single_world_application")]
+        #[cfg(not(feature = "flecs_multi_world_application"))]
         T::__reset_one_lock_data();
     }
 
-    #[cfg(feature = "flecs_single_world_application")]
+    #[cfg(not(feature = "flecs_multi_world_application"))]
     macro_rules! reset_components {
         ($($type:ty),*) => {{
             $(
@@ -113,12 +113,12 @@ pub mod common {
         }};
     }
 
-    #[cfg(not(feature = "flecs_single_world_application"))]
+    #[cfg(feature = "flecs_multi_world_application")]
     macro_rules! reset_components {
         ($($type:ty),*) => {};
     }
 
-    #[cfg(not(feature = "flecs_single_world_application"))]
+    #[cfg(feature = "flecs_multi_world_application")]
     macro_rules! reset_component_range {
         ($component:ty, $start:expr, $end:expr) => {};
     }

--- a/flecs_ecs/src/core/component_registration/registration.rs
+++ b/flecs_ecs/src/core/component_registration/registration.rs
@@ -12,12 +12,12 @@ pub(crate) fn try_register_component_impl<'a, T>(
 where
     T: ComponentId,
 {
-    #[cfg(feature = "flecs_single_world_application")]
+    #[cfg(not(feature = "flecs_multi_world_application"))]
     {
         register_component_single_world_application::<T>(&world, name)
     }
 
-    #[cfg(not(feature = "flecs_single_world_application"))]
+    #[cfg(feature = "flecs_multi_world_application")]
     {
         register_component_multi_world_application::<T>(&world, name)
     }


### PR DESCRIPTION
This makes it easier to have single world support enabled by default but able to opt into multi, rather than having opted into single world and it is harder to get back to multiworld.

Tests often need multiworld support since they might be creating and destroying lots of worlds on various threads.