### PR TITLE
Rename some `InOutKind` variants.

### DIFF
--- a/flecs_ecs/src/core/c_types.rs
+++ b/flecs_ecs/src/core/c_types.rs
@@ -44,9 +44,9 @@ pub static SEPARATOR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"::\
 ///
 /// Variants:
 ///
-/// - `InOutDefault`: Default behavior, which is `InOut` for regular terms and `In` for shared terms.
-/// - `InOutNone`: Indicates the term is neither read nor written by the system.
-/// - `InOutFilter`: Same as `InOutNOne` + prevents term from triggering observers
+/// - `Default`: Default behavior, which is `InOut` for regular terms and `In` for shared terms.
+/// - `None`: Indicates the term is neither read nor written by the system.
+/// - `Filter`: Same as `None` + prevents term from triggering observers
 /// - `InOut`: The term is both read and written, implying a mutable access to the component data.
 /// - `In`: The term is only read, implying an immutable access to the component data.
 /// - `Out`: The term is only written, providing exclusive access to modify the component data.
@@ -54,9 +54,9 @@ pub static SEPARATOR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"::\
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum InOutKind {
-    InOutDefault = sys::ecs_inout_kind_t_EcsInOutDefault as u32,
-    InOutNone = sys::ecs_inout_kind_t_EcsInOutNone as u32,
-    InOutFilter = sys::ecs_inout_kind_t_EcsInOutFilter as u32,
+    Default = sys::ecs_inout_kind_t_EcsInOutDefault as u32,
+    None = sys::ecs_inout_kind_t_EcsInOutNone as u32,
+    Filter = sys::ecs_inout_kind_t_EcsInOutFilter as u32,
     InOut = sys::ecs_inout_kind_t_EcsInOut as u32,
     In = sys::ecs_inout_kind_t_EcsIn as u32,
     Out = sys::ecs_inout_kind_t_EcsOut as u32,
@@ -71,13 +71,13 @@ impl InOutKind {
 impl From<sys::ecs_inout_kind_t> for InOutKind {
     fn from(value: sys::ecs_inout_kind_t) -> Self {
         match value {
-            sys::ecs_inout_kind_t_EcsInOutDefault => InOutKind::InOutDefault,
-            sys::ecs_inout_kind_t_EcsInOutNone => InOutKind::InOutNone,
+            sys::ecs_inout_kind_t_EcsInOutDefault => InOutKind::Default,
+            sys::ecs_inout_kind_t_EcsInOutNone => InOutKind::None,
+            sys::ecs_inout_kind_t_EcsInOutFilter => InOutKind::Filter,
             sys::ecs_inout_kind_t_EcsInOut => InOutKind::InOut,
             sys::ecs_inout_kind_t_EcsIn => InOutKind::In,
             sys::ecs_inout_kind_t_EcsOut => InOutKind::Out,
-            sys::ecs_inout_kind_t_EcsInOutFilter => InOutKind::InOutFilter,
-            _ => InOutKind::InOutDefault,
+            _ => InOutKind::Default,
         }
     }
 }
@@ -92,13 +92,13 @@ const EcsInOutFilter: i16 = sys::ecs_inout_kind_t_EcsInOutFilter as i16;
 impl From<i16> for InOutKind {
     fn from(value: i16) -> Self {
         match value {
-            EcsInOutDefault => InOutKind::InOutDefault,
-            EcsInOutNone => InOutKind::InOutNone,
+            EcsInOutDefault => InOutKind::Default,
+            EcsInOutNone => InOutKind::None,
+            EcsInOutFilter => InOutKind::Filter,
             EcsInOut => InOutKind::InOut,
             EcsIn => InOutKind::In,
             EcsOut => InOutKind::Out,
-            EcsInOutFilter => InOutKind::InOutFilter,
-            _ => InOutKind::InOutDefault,
+            _ => InOutKind::Default,
         }
     }
 }
@@ -106,12 +106,12 @@ impl From<i16> for InOutKind {
 impl From<InOutKind> for i16 {
     fn from(value: InOutKind) -> Self {
         match value {
-            InOutKind::InOutDefault => sys::ecs_inout_kind_t_EcsInOutDefault as i16,
-            InOutKind::InOutNone => sys::ecs_inout_kind_t_EcsInOutNone as i16,
+            InOutKind::Default => sys::ecs_inout_kind_t_EcsInOutDefault as i16,
+            InOutKind::None => sys::ecs_inout_kind_t_EcsInOutNone as i16,
+            InOutKind::Filter => sys::ecs_inout_kind_t_EcsInOutFilter as i16,
             InOutKind::InOut => sys::ecs_inout_kind_t_EcsInOut as i16,
             InOutKind::In => sys::ecs_inout_kind_t_EcsIn as i16,
             InOutKind::Out => sys::ecs_inout_kind_t_EcsOut as i16,
-            InOutKind::InOutFilter => sys::ecs_inout_kind_t_EcsInOutFilter as i16,
         }
     }
 }

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -299,7 +299,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.term();
         self.init_current_term(id);
         let current_term = self.current_term_mut();
-        if current_term.inout == InOutKind::InOutDefault as i16 {
+        if current_term.inout == InOutKind::Default as i16 {
             self.set_inout_none();
         }
         self
@@ -434,7 +434,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.term();
         self.set_first_name(name);
         let term = self.current_term();
-        if term.inout == InOutKind::InOutDefault as i16 {
+        if term.inout == InOutKind::Default as i16 {
             self.set_inout_none();
         }
         self
@@ -450,7 +450,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.term();
         self.set_first_name(first).set_second_name(second);
         let term = self.current_term();
-        if term.inout == InOutKind::InOutDefault as i16 {
+        if term.inout == InOutKind::Default as i16 {
             self.set_inout_none();
         }
         self
@@ -462,7 +462,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.init_current_term(first.into());
         self.set_second_name(second);
         let term = self.current_term();
-        if term.inout == InOutKind::InOutDefault as i16 {
+        if term.inout == InOutKind::Default as i16 {
             self.set_inout_none();
         }
         self
@@ -473,7 +473,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.term();
         self.set_first_name(first).set_second_id(second.into());
         let term = self.current_term();
-        if term.inout == InOutKind::InOutDefault as i16 {
+        if term.inout == InOutKind::Default as i16 {
             self.set_inout_none();
         }
         self

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -919,7 +919,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
         self.set_inout_kind(InOutKind::InOut)
     }
 
-    /// short for `set_inout(InOutKind::InOutNone)`
+    /// short for `set_inout(InOutKind::None)`
     ///
     /// # See also
     ///
@@ -929,7 +929,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::inout_none")]
     #[inline(always)]
     fn set_inout_none(&mut self) -> &mut Self {
-        self.set_inout_kind(InOutKind::InOutNone)
+        self.set_inout_kind(InOutKind::None)
     }
 
     /// set operator of term
@@ -1080,7 +1080,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::filter")]
     #[inline(always)]
     fn filter(&mut self) -> &mut Self {
-        self.current_term_mut().inout |= InOutKind::InOutFilter as i16;
+        self.current_term_mut().inout |= InOutKind::Filter as i16;
         self
     }
 }

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -3521,7 +3521,7 @@ fn query_builder_inout_shortcuts() {
 
     t = query.term(3);
     assert_eq!(t.id(), d);
-    assert_eq!(t.inout(), InOutKind::InOutNone);
+    assert_eq!(t.inout(), InOutKind::None);
 }
 
 #[test]
@@ -4552,7 +4552,7 @@ fn query_builder_with_t_inout() {
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    assert_eq!(f.term(0).inout(), InOutKind::InOutNone);
+    assert_eq!(f.term(0).inout(), InOutKind::None);
 }
 
 #[test]
@@ -4580,7 +4580,7 @@ fn query_builder_with_r_t_inout_2() {
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    assert_eq!(f.term(0).inout(), InOutKind::InOutNone);
+    assert_eq!(f.term(0).inout(), InOutKind::None);
 }
 
 #[test]
@@ -4594,7 +4594,7 @@ fn query_builder_with_r_t_inout_3() {
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    assert_eq!(f.term(0).inout(), InOutKind::InOutNone);
+    assert_eq!(f.term(0).inout(), InOutKind::None);
 }
 
 #[test]
@@ -4611,7 +4611,7 @@ fn query_builder_with_r_t_inout() {
         .set_cache_kind(QueryCacheKind::Auto)
         .build();
 
-    assert_eq!(f.term(0).inout(), InOutKind::InOutNone);
+    assert_eq!(f.term(0).inout(), InOutKind::None);
 }
 
 #[test]


### PR DESCRIPTION
This renames 3 of the `InOutKind` variants to not have `InOut` in the name.

Also, re-order some branches to match the order in C.