### PR TITLE
Improvements for query-like operations, validity + safety checking for term+adding id's, introduction to `run`, make types Send & Sync, see description for more. 

### DIFF
--- a/flecs_ecs/benches/flecs/event_bench.rs
+++ b/flecs_ecs/benches/flecs/event_bench.rs
@@ -15,7 +15,7 @@ pub fn event_emit(criterion: &mut Criterion) {
                     .observer_id::<()>(evt)
                     .with::<&T1>()
                     .self_()
-                    .iter_only(|_| {});
+                    .run(|_| {});
             }
 
             bencher.iter_custom(|iters| {
@@ -56,7 +56,7 @@ pub fn event_emit_propagate(criterion: &mut Criterion) {
                 .observer_id::<()>(evt.id())
                 .with::<&T1>()
                 .parent()
-                .iter_only(|_| {});
+                .run(|_| {});
 
             bencher.iter_custom(|iters| {
                 let start = Instant::now();
@@ -94,7 +94,7 @@ pub fn event_emit_forward(criterion: &mut Criterion) {
                     .observer::<flecs::OnAdd, ()>()
                     .with_id(*id)
                     .add_event::<flecs::OnRemove>()
-                    .iter_only(|_| {});
+                    .run(|_| {});
             }
 
             add_component_range!(world, root, T, 1, 1);
@@ -132,7 +132,7 @@ pub fn event_emit_forward(criterion: &mut Criterion) {
                     .observer::<flecs::OnAdd, ()>()
                     .with_id(*id)
                     .add_event::<flecs::OnRemove>()
-                    .iter_only(|_| {});
+                    .run(|_| {});
             }
 
             add_component_range!(world, root, T, 1, 16);
@@ -170,7 +170,7 @@ pub fn event_modified(criterion: &mut Criterion) {
                     .observer::<flecs::OnSet, ()>()
                     .with::<&C1>()
                     .self_()
-                    .iter_only(|_| {});
+                    .run(|_| {});
             }
 
             let id = *world.entity_from::<C1>();

--- a/flecs_ecs/examples/flecs/query_basics.rs
+++ b/flecs_ecs/examples/flecs/query_basics.rs
@@ -55,7 +55,7 @@ fn main() {
     // Iter is a bit more verbose, but allows for more control over how entities
     // are iterated as it provides multiple entities in the same callback.
     // There's also an `iter_only` function that only provides the iterator.
-    query.iter(|it, (pos, vel)| {
+    query.run_iter(|it, (pos, vel)| {
         for i in it.iter() {
             pos[i].x += vel[i].x;
             pos[i].y += vel[i].y;

--- a/flecs_ecs/examples/flecs/query_chaining_queries.rs
+++ b/flecs_ecs/examples/flecs/query_chaining_queries.rs
@@ -65,7 +65,7 @@ fn main() {
     let query_enchanted = forest.query::<()>().with::<&Enchanted>().build();
 
     // Iterate over creatures to find the enchanted ones
-    query_creatures.iter(|iter, (loc, ability)| {
+    query_creatures.run_iter(|iter, (loc, ability)| {
 
         // Filter for enchanted creatures within the current iteration
         query_enchanted

--- a/flecs_ecs/examples/flecs/query_group_by.rs
+++ b/flecs_ecs/examples/flecs/query_group_by.rs
@@ -63,7 +63,7 @@ fn main() {
 
     println!();
 
-    query.iter(|it, pos| {
+    query.run_iter(|it, pos| {
         let group = world.entity_from_id(it.group_id());
         println!(
             "Group: {:?} - Table: [{:?}]",

--- a/flecs_ecs/examples/flecs/query_group_by_callbacks.rs
+++ b/flecs_ecs/examples/flecs/query_group_by_callbacks.rs
@@ -135,7 +135,7 @@ fn main() {
     //     - table [Position, Tag, (Group, Third)]
     //
 
-    query.iter(|it, (pos,)| {
+    query.run_iter(|it, (pos,)| {
         let group = world.entity_from_id(it.group_id());
         let ctx = unsafe { &*(query.group_context(group) as *mut GroupCtx) };
         println!(

--- a/flecs_ecs/examples/flecs/query_group_by_custom.rs
+++ b/flecs_ecs/examples/flecs/query_group_by_custom.rs
@@ -104,7 +104,7 @@ fn main() {
     //     - table [Position, Tag, (Group, Third)]
     //
 
-    query.iter(|it, pos| {
+    query.run_iter(|it, pos| {
         let group = world.entity_from_id(it.group_id());
         println!(
             "Group: {:?} - Table: [{:?}]",

--- a/flecs_ecs/examples/flecs/query_group_iter.rs
+++ b/flecs_ecs/examples/flecs/query_group_iter.rs
@@ -49,6 +49,7 @@ struct Beggar;
 #[derive(Debug, Component)]
 struct Mage;
 
+#[test]
 fn main() {
     let world = World::new();
 
@@ -100,27 +101,31 @@ fn main() {
     // Iterate all tables
     println!("All tables");
 
-    query.iter_only(|iter| {
-        let group = world.entity_from_id(iter.group_id());
-        println!(
-            "group: {:?} - Table [{}]",
-            group.path().unwrap(),
-            iter.table().unwrap().to_string().unwrap()
-        );
+    query.run(|mut iter| {
+        while iter.next_iter() {
+            let group = world.entity_from_id(iter.group_id());
+            println!(
+                "group: {:?} - Table [{}]",
+                group.path().unwrap(),
+                iter.table().unwrap().to_string().unwrap()
+            );
+        }
     });
 
     println!();
 
     println!("Tables for cell 1_0:");
 
-    query.iterable().set_group::<Cell_1_0>().iter_only(|iter| {
-        let world = iter.world();
-        let group = world.entity_from_id(iter.group_id());
-        println!(
-            "group: {:?} - Table [{}]",
-            group.path().unwrap(),
-            iter.table().unwrap().to_string().unwrap()
-        );
+    query.iterable().set_group::<Cell_1_0>().run(|mut iter| {
+        while iter.next_iter() {
+            let world = iter.world();
+            let group = world.entity_from_id(iter.group_id());
+            println!(
+                "group: {:?} - Table [{}]",
+                group.path().unwrap(),
+                iter.table().unwrap().to_string().unwrap()
+            );
+        }
     });
 
     // Output:

--- a/flecs_ecs/examples/flecs/query_group_iter.rs
+++ b/flecs_ecs/examples/flecs/query_group_iter.rs
@@ -96,7 +96,11 @@ fn main() {
         .add::<Soldier>()
         .add::<Npc>();
 
-    let query = world.query::<&Npc>().group_by::<WorldCell>().build();
+    let query = world
+        .query::<()>()
+        .with::<&Npc>()
+        .group_by::<WorldCell>()
+        .build();
 
     // Iterate all tables
     println!("All tables");

--- a/flecs_ecs/examples/flecs/query_hierarchy.rs
+++ b/flecs_ecs/examples/flecs/query_hierarchy.rs
@@ -63,7 +63,7 @@ fn main() {
         // we have tests in place to ensure that the `Option` API is working as expected.
         .build();
 
-    query.iter(|it, (local, parent_world, world)| {
+    query.run_iter(|it, (local, parent_world, world)| {
         for i in it.iter() {
             world[i].x = local[i].x;
             world[i].y = local[i].y;

--- a/flecs_ecs/examples/flecs/query_instancing.rs
+++ b/flecs_ecs/examples/flecs/query_instancing.rs
@@ -62,7 +62,7 @@ fn main() {
     // to check whether a field is owned or not in order to know how to access
     // it. In the case of an owned field it is iterated as an array, whereas
     // in the case of a shared field, it is accessed as a pointer.
-    query.iter(|it, (position, velocity)| {
+    query.run_iter(|it, (position, velocity)| {
         // Check if Velocity is owned, in which case it's accessed as array.
         // Position will always be owned, since we set the term to Self.
         if it.is_self(1) {

--- a/flecs_ecs/examples/flecs/query_iter.rs
+++ b/flecs_ecs/examples/flecs/query_iter.rs
@@ -45,7 +45,7 @@ fn main() {
     // of information on the entities currently being iterated.
     // The function passed to iter is by default called for each table the query
     // is matched with.
-    query.iter(|it, (position, velocity)| {
+    query.run_iter(|it, (position, velocity)| {
         println!();
         // Print the table & number of entities matched in current callback
         println!("Table: {:?}", it.archetype());

--- a/flecs_ecs/examples/flecs/relationships_component_data.rs
+++ b/flecs_ecs/examples/flecs/relationships_component_data.rs
@@ -7,7 +7,7 @@ use flecs_ecs::prelude::*;
 
 // Some demo components:
 
-#[derive(Debug, Component)]
+#[derive(Debug, Component, Default)]
 pub struct Position {
     pub x: f32,
     pub y: f32,
@@ -81,11 +81,8 @@ fn main() {
 
     // Even though Position is a component, <MustHave, Position> contains no
     // data because MustHave has the Tag property.
-    world
-        .entity()
-        .set_pair::<MustHave, Position>(Position { x: 4.0, y: 5.0 });
+    world.entity().add::<(MustHave, Position)>(); // due to a Rust limitation, Position requires Default to add this sort of relationship.
 
-    // The id::type_id method can be used to find the component type for a pair:
     println!(
         "{}",
         world
@@ -144,7 +141,6 @@ fn main() {
 
 #[cfg(feature = "flecs_nightly_tests")]
 #[test]
-#[ignore = "PairIsTag with add only allowing tags is problematic, set asserts."]
 fn test() {
     let output_capture = OutputCapture::capture().unwrap();
     main();

--- a/flecs_ecs/examples/flecs/relationships_component_data.rs
+++ b/flecs_ecs/examples/flecs/relationships_component_data.rs
@@ -39,7 +39,7 @@ fn main() {
     // the pair assumes the type of the component.
     let e1 = world
         .entity()
-        .set_pair::<_, Gigawatts>(Requires { amount: 1.21 });
+        .set_pair::<Requires, Gigawatts>(Requires { amount: 1.21 });
 
     let require = e1.try_get::<Option<&(Requires, Gigawatts)>>(|req| {
         if let Some((req)) = req {

--- a/flecs_ecs/examples/flecs/rules_component_inheritance.rs
+++ b/flecs_ecs/examples/flecs/rules_component_inheritance.rs
@@ -55,7 +55,7 @@ fn main() {
     world.entity_named("builder_2").add::<BuilderX>();
 
     // Create a rule to find all ranged units
-    let r = world.new_query::<&RangedUnit>();
+    let r = world.query::<()>().with::<&RangedUnit>().build();
 
     // Iterate the rule
     r.each_entity(|e, _| {

--- a/flecs_ecs/examples/flecs/rules_component_inheritance.rs
+++ b/flecs_ecs/examples/flecs/rules_component_inheritance.rs
@@ -55,10 +55,10 @@ fn main() {
     world.entity_named("builder_2").add::<BuilderX>();
 
     // Create a rule to find all ranged units
-    let r = world.query::<()>().with::<&RangedUnit>().build();
+    let r = world.query::<&RangedUnit>().build();
 
     // Iterate the rule
-    r.each_entity(|e, _| {
+    r.each_entity(|e, rangedunit| {
         println!("Unit {} found", e.name());
     });
 

--- a/flecs_ecs/examples/flecs/rules_cyclic_variables.rs
+++ b/flecs_ecs/examples/flecs/rules_cyclic_variables.rs
@@ -7,6 +7,7 @@ use flecs_ecs::prelude::*;
 #[derive(Component)]
 struct Likes;
 
+#[test]
 fn main() {
     let world = World::new();
 
@@ -50,10 +51,12 @@ fn main() {
 
     // Because the query doesn't use the This variable we cannot use "each"
     // which iterates the entities array. Instead we can use iter like this:
-    rule.iter_only(|it| {
-        let x = it.get_var(x_var);
-        let y = it.get_var(y_var);
-        println!("{} likes {}", x.name(), y.name());
+    rule.run(|mut it| {
+        while it.next_iter() {
+            let x = it.get_var(x_var);
+            let y = it.get_var(y_var);
+            println!("{} likes {}", x.name(), y.name());
+        }
     });
 
     // Output:

--- a/flecs_ecs/examples/flecs/system_custom_phases.rs
+++ b/flecs_ecs/examples/flecs/system_custom_phases.rs
@@ -6,8 +6,10 @@ use flecs_ecs::prelude::*;
 // they have the flecs::Phase tag.
 
 // Dummy system
-fn sys(it: Iter) {
-    println!("system {}", it.system().name());
+fn sys(mut it: Iter) {
+    while it.next_iter() {
+        println!("system {}", it.system().name());
+    }
 }
 
 fn main() {
@@ -30,17 +32,17 @@ fn main() {
     world
         .system_named::<()>("CollisionSystem")
         .kind_id(collisions)
-        .iter_only(sys);
+        .run(sys);
 
     world
         .system_named::<()>("PhysicsSystem")
         .kind_id(physics)
-        .iter_only(sys);
+        .run(sys);
 
     world
         .system_named::<()>("GameSystem")
         .kind::<flecs::pipeline::OnUpdate>()
-        .iter_only(sys);
+        .run(sys);
 
     // Run pipeline
     world.progress();

--- a/flecs_ecs/examples/flecs/system_custom_phases_no_builtin.rs
+++ b/flecs_ecs/examples/flecs/system_custom_phases_no_builtin.rs
@@ -6,8 +6,10 @@ use flecs_ecs::prelude::*;
 // they have the flecs::Phase tag.
 
 // Dummy system
-fn sys(it: Iter) {
-    println!("system {}", it.system().name());
+fn sys(mut it: Iter) {
+    while it.next_iter() {
+        println!("system {}", it.system().name());
+    }
 }
 
 fn main() {
@@ -33,17 +35,17 @@ fn main() {
     world
         .system_named::<()>("CollisionSystem")
         .kind_id(collisions)
-        .iter_only(sys);
+        .run(sys);
 
     world
         .system_named::<()>("PhysicsSystem")
         .kind_id(physics)
-        .iter_only(sys);
+        .run(sys);
 
     world
         .system_named::<()>("GameSystem")
         .kind_id(update)
-        .iter_only(sys);
+        .run(sys);
 
     // Run pipeline
     world.progress();

--- a/flecs_ecs/examples/flecs/system_custom_pipeline.rs
+++ b/flecs_ecs/examples/flecs/system_custom_pipeline.rs
@@ -28,13 +28,17 @@ fn main() {
     world.set_pipeline(pipeline.entity());
 
     // Create system with Physics tag
-    world.system::<()>().kind::<Physics>().iter_only(|it| {
-        println!("System with Physics ran!");
+    world.system::<()>().kind::<Physics>().run(|mut it| {
+        while it.next_iter() {
+            println!("System with Physics ran!");
+        }
     });
 
     // Create system without Physics tag
-    world.system::<()>().iter_only(|it| {
-        println!("System without Physics ran!");
+    world.system::<()>().run(|mut it| {
+        while it.next_iter() {
+            println!("System without Physics ran!");
+        }
     });
 
     // Runs the pipeline & system

--- a/flecs_ecs/examples/flecs/system_custom_runner.rs
+++ b/flecs_ecs/examples/flecs/system_custom_runner.rs
@@ -1,81 +1,83 @@
-use crate::z_ignore_test_common::*;
+// TODO outdated.
 
-use flecs_ecs::prelude::*;
+// use crate::z_ignore_test_common::*;
 
-#[derive(Debug, Component)]
-pub struct Position {
-    pub x: f32,
-    pub y: f32,
-}
+// use flecs_ecs::prelude::*;
 
-#[derive(Debug, Component)]
-pub struct Velocity {
-    pub x: f32,
-    pub y: f32,
-}
+// #[derive(Debug, Component)]
+// pub struct Position {
+//     pub x: f32,
+//     pub y: f32,
+// }
 
-// Systems can be created with a custom run function that takes control over the
-// entire iteration. By  a system is invoked once per matched table,
-// which means the function can be called multiple times per frame. In some
-// cases that's inconvenient, like when a system has things it needs to do only
-// once per frame. For these use cases, the run callback can be used which is
-// called once per frame per system.
+// #[derive(Debug, Component)]
+// pub struct Velocity {
+//     pub x: f32,
+//     pub y: f32,
+// }
 
-extern "C" fn run_callback(it: *mut IterT) {
-    let world_ref = unsafe { WorldRef::from_ptr((*it).world) };
-    println!("Move begin");
+// // Systems can be created with a custom run function that takes control over the
+// // entire iteration. By  a system is invoked once per matched table,
+// // which means the function can be called multiple times per frame. In some
+// // cases that's inconvenient, like when a system has things it needs to do only
+// // once per frame. For these use cases, the run callback can be used which is
+// // called once per frame per system.
 
-    // Walk over the iterator, forward to the system callback
-    while unsafe { flecs_ecs_sys::ecs_iter_next(it) } {
-        unsafe { ((*it).callback).unwrap()(it) };
-    }
+// extern "C" fn run_callback(it: *mut IterT) {
+//     let world_ref = unsafe { WorldRef::from_ptr((*it).world) };
+//     println!("Move begin");
 
-    println!("Move end");
-}
+//     // Walk over the iterator, forward to the system callback
+//     while unsafe { flecs_ecs_sys::ecs_iter_next(it) } {
+//         unsafe { ((*it).callback).unwrap()(it) };
+//     }
 
-fn main() {
-    let world = World::new();
+//     println!("Move end");
+// }
 
-    let system = world
-        .system::<(&mut Position, &Velocity)>()
-        // The run function has a signature that accepts a C iterator. By
-        // forwarding the iterator to it->callback, the each function of the
-        // system is invoked.
-        .set_run_callback(Some(run_callback)) // this will be rustified in the future to take a closure
-        .each_entity(|e, (pos, vel)| {
-            pos.x += vel.x;
-            pos.y += vel.y;
-            println!("{}: {{ {}, {} }}", e.name(), pos.x, pos.y);
-        });
+// fn main() {
+//     let world = World::new();
 
-    // Create a few test entities for a Position, Velocity query
-    world
-        .entity_named("e1")
-        .set(Position { x: 10.0, y: 20.0 })
-        .set(Velocity { x: 1.0, y: 2.0 });
+//     let system = world
+//         .system::<(&mut Position, &Velocity)>()
+//         // The run function has a signature that accepts a C iterator. By
+//         // forwarding the iterator to it->callback, the each function of the
+//         // system is invoked.
+//         .set_run_callback(Some(run_callback)) // this will be rustified in the future to take a closure
+//         .each_entity(|e, (pos, vel)| {
+//             pos.x += vel.x;
+//             pos.y += vel.y;
+//             println!("{}: {{ {}, {} }}", e.name(), pos.x, pos.y);
+//         });
 
-    world
-        .entity_named("e2")
-        .set(Position { x: 10.0, y: 20.0 })
-        .set(Velocity { x: 3.0, y: 4.0 });
+//     // Create a few test entities for a Position, Velocity query
+//     world
+//         .entity_named("e1")
+//         .set(Position { x: 10.0, y: 20.0 })
+//         .set(Velocity { x: 1.0, y: 2.0 });
 
-    // This entity will not match as it does not have Position, Velocity
-    world.entity_named("e3").set(Position { x: 10.0, y: 20.0 });
+//     world
+//         .entity_named("e2")
+//         .set(Position { x: 10.0, y: 20.0 })
+//         .set(Velocity { x: 3.0, y: 4.0 });
 
-    // Run the system
-    system.run();
+//     // This entity will not match as it does not have Position, Velocity
+//     world.entity_named("e3").set(Position { x: 10.0, y: 20.0 });
 
-    // Output:
-    //  Move begin
-    //  e1: {11, 22}
-    //  e2: {13, 24}
-    //  Move end
-}
+//     // Run the system
+//     system.run();
 
-#[cfg(feature = "flecs_nightly_tests")]
-#[test]
-fn test() {
-    let output_capture = OutputCapture::capture().unwrap();
-    main();
-    output_capture.test("system_custom_runner".to_string());
-}
+//     // Output:
+//     //  Move begin
+//     //  e1: {11, 22}
+//     //  e2: {13, 24}
+//     //  Move end
+// }
+
+// #[cfg(feature = "flecs_nightly_tests")]
+// #[test]
+// fn test() {
+//     let output_capture = OutputCapture::capture().unwrap();
+//     main();
+//     output_capture.test("system_custom_runner".to_string());
+// }

--- a/flecs_ecs/examples/flecs/system_delta_time.rs
+++ b/flecs_ecs/examples/flecs/system_delta_time.rs
@@ -8,8 +8,10 @@ fn main() {
     // Create system that prints delta_time. This system doesn't query for any
     // components which means it won't match any entities, but will still be ran
     // once for each call to ecs_progress.
-    world.system::<()>().iter_only(|it| {
-        println!("delta_time: {}", it.delta_time());
+    world.system::<()>().run(|mut it| {
+        while it.next_iter() {
+            println!("delta_time: {}", it.delta_time());
+        }
     });
 
     // Call progress with 0.0f for the delta_time parameter. This will cause

--- a/flecs_ecs/examples/flecs/system_startup_system.rs
+++ b/flecs_ecs/examples/flecs/system_startup_system.rs
@@ -17,13 +17,17 @@ fn main() {
     world
         .system_named::<()>("Startup")
         .kind::<flecs::pipeline::OnStart>()
-        .iter_only(|it| {
-            println!("{}", it.system().name());
+        .run(|mut it| {
+            while it.next_iter() {
+                println!("{}", it.system().name());
+            }
         });
 
     // Regular system
-    world.system_named::<()>("Update").iter_only(|it| {
-        println!("{}", it.system().name());
+    world.system_named::<()>("Update").run(|mut it| {
+        while it.next_iter() {
+            println!("{}", it.system().name());
+        }
     });
 
     // First frame. This runs both the Startup and Update systems

--- a/flecs_ecs/examples/flecs/system_target_fps.rs
+++ b/flecs_ecs/examples/flecs/system_target_fps.rs
@@ -8,8 +8,10 @@ fn main() {
     // Create system that prints delta_time. This system doesn't query for any
     // components which means it won't match any entities, but will still be ran
     // once for each call to ecs_progress.
-    world.system::<()>().iter_only(|it| {
-        println!("Delta time: {}", it.delta_time());
+    world.system::<()>().run(|mut it| {
+        while it.next_iter() {
+            println!("Delta time: {}", it.delta_time());
+        }
     });
 
     // Set target FPS to 1 frame per second

--- a/flecs_ecs/examples/flecs/system_time_interval.rs
+++ b/flecs_ecs/examples/flecs/system_time_interval.rs
@@ -8,8 +8,10 @@ struct Timeout {
     pub value: f32,
 }
 
-fn tick(it: Iter) {
-    println!("{}", it.system().name());
+fn tick(mut it: Iter) {
+    while it.next_iter() {
+        println!("{}", it.system().name());
+    }
 }
 
 fn main() {
@@ -23,15 +25,9 @@ fn main() {
             timeout.value -= it.delta_time();
         });
 
-    world
-        .system_named::<()>("Tick")
-        .interval(1.0)
-        .iter_only(tick);
+    world.system_named::<()>("Tick").interval(1.0).run(tick);
 
-    world
-        .system_named::<()>("FastTick")
-        .interval(0.5)
-        .iter_only(tick);
+    world.system_named::<()>("FastTick").interval(0.5).run(tick);
 
     // Run the main loop at 60 FPS
     world.set_target_fps(60.0);

--- a/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
+++ b/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
@@ -140,7 +140,7 @@ impl<'a, T: Iterable> internals::QueryConfig<'a> for PipelineBuilder<'a, T> {
     }
 
     #[inline(always)]
-    fn count_generic_terms(&mut self) -> i32 {
+    fn count_generic_terms(&self) -> i32 {
         T::COUNT
     }
 }

--- a/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
+++ b/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
@@ -138,6 +138,11 @@ impl<'a, T: Iterable> internals::QueryConfig<'a> for PipelineBuilder<'a, T> {
     fn query_desc_mut(&mut self) -> &mut sys::ecs_query_desc_t {
         &mut self.desc.query
     }
+
+    #[inline(always)]
+    fn count_generic_terms(&mut self) -> i32 {
+        T::COUNT
+    }
 }
 
 impl<'a, T: Iterable> QueryBuilderImpl<'a> for PipelineBuilder<'a, T> {}

--- a/flecs_ecs/src/addons/system/mod.rs
+++ b/flecs_ecs/src/addons/system/mod.rs
@@ -56,11 +56,6 @@ impl<'a> System<'a> {
             );
         }
 
-        /*
-                if (!(desc->query.flags & EcsQueryIsInstanced)) {
-            ECS_BIT_COND(desc->query.flags, EcsQueryIsInstanced, instanced);
-        } */
-
         let id = unsafe { sys::ecs_system_init(world.world_ptr_mut(), &desc) };
         let entity = EntityView::new_from(world.world(), id);
 

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -319,6 +319,10 @@ impl<'a, T: Iterable> internals::QueryConfig<'a> for SystemBuilder<'a, T> {
     fn query_desc_mut(&mut self) -> &mut sys::ecs_query_desc_t {
         &mut self.desc.query
     }
+    #[inline(always)]
+    fn count_generic_terms(&mut self) -> i32 {
+        T::COUNT
+    }
 }
 
 impl<'a, T: Iterable> TermBuilderImpl<'a> for SystemBuilder<'a, T> {}

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -320,7 +320,7 @@ impl<'a, T: Iterable> internals::QueryConfig<'a> for SystemBuilder<'a, T> {
         &mut self.desc.query
     }
     #[inline(always)]
-    fn count_generic_terms(&mut self) -> i32 {
+    fn count_generic_terms(&self) -> i32 {
         T::COUNT
     }
 }

--- a/flecs_ecs/src/core/component_registration/helpers.rs
+++ b/flecs_ecs/src/core/component_registration/helpers.rs
@@ -32,6 +32,12 @@ where
         // require construction/destruction/copy/move's.
         T::__register_lifecycle_hooks(&mut hooks);
     }
+    if T::IMPLS_DEFAULT {
+        T::__register_default_hooks(&mut hooks);
+    }
+    if T::IMPLS_CLONE {
+        T::__register_clone_hooks(&mut hooks);
+    }
 
     let type_info: flecs_ecs_sys::ecs_type_info_t = flecs_ecs_sys::ecs_type_info_t {
         size: size as i32,

--- a/flecs_ecs/src/core/component_registration/registration_traits.rs
+++ b/flecs_ecs/src/core/component_registration/registration_traits.rs
@@ -11,7 +11,7 @@ where
 }
 
 #[diagnostic::on_unimplemented(
-    message = "the size of type `{Self}` should not be zero, should not a tag.",
+    message = "the size of type `{Self}` should not be zero, should not be a tag.",
     label = "Supports only non-empty components"
 )]
 pub trait NotEmptyComponent {}
@@ -20,6 +20,16 @@ impl<T> NotEmptyComponent for &T where T: NotEmptyComponent {}
 impl<T> NotEmptyComponent for &mut T where T: NotEmptyComponent {}
 impl<T> NotEmptyComponent for Option<&T> where T: NotEmptyComponent {}
 impl<T> NotEmptyComponent for Option<&mut T> where T: NotEmptyComponent {}
+impl<T, U> NotEmptyComponent for (T, U)
+where
+    (T, U): IntoComponentId,
+    <(T, U) as FlecsCastType>::CastType: NotEmptyComponent,
+    registration_types::ConditionalTypePairSelector<
+        <<(T, U) as IntoComponentId>::First as registration_traits::ComponentInfo>::TagType,
+        (T, U),
+    >: registration_traits::FlecsPairType,
+{
+}
 
 pub trait ECSComponentType {}
 
@@ -298,7 +308,7 @@ pub trait FlecsCloneType {
 }
 
 pub trait FlecsPairType {
-    type Type: ComponentId + NotEmptyComponent;
+    type Type: ComponentId;
     const IS_FIRST: bool;
 }
 
@@ -330,7 +340,7 @@ pub struct FlecsFirstIsATag;
 impl<T> FlecsPairType for ConditionalTypePairSelector<FlecsFirstIsNotATag, T>
 where
     T: IntoComponentId,
-    T::First: NotEmptyComponent + ComponentId,
+    T::First: ComponentId,
 {
     type Type = T::First;
     const IS_FIRST: bool = true;
@@ -339,14 +349,14 @@ where
 impl<U> FlecsPairType for ConditionalTypePairSelector<FlecsFirstIsATag, U>
 where
     U: IntoComponentId,
-    U::Second: NotEmptyComponent + ComponentId,
+    U::Second: ComponentId,
 {
     type Type = U::Second;
     const IS_FIRST: bool = false;
 }
 
 pub trait FlecsCastType: IntoComponentId {
-    type CastType: NotEmptyComponent + ComponentId;
+    type CastType: ComponentId;
     const IS_FIRST: bool;
 }
 

--- a/flecs_ecs/src/core/component_registration/registration_traits.rs
+++ b/flecs_ecs/src/core/component_registration/registration_traits.rs
@@ -139,7 +139,15 @@ pub trait ComponentId: Sized + ComponentInfo + 'static {
 
     // Not public API.
     #[doc(hidden)]
-    fn __register_lifecycle_hooks(mut _type_hooks: &mut TypeHooksT) {}
+    fn __register_lifecycle_hooks(_type_hooks: &mut TypeHooksT) {}
+
+    // Not public API.
+    #[doc(hidden)]
+    fn __register_default_hooks(_type_hooks: &mut TypeHooksT) {}
+
+    // Not public API.
+    #[doc(hidden)]
+    fn __register_clone_hooks(_type_hooks: &mut TypeHooksT) {}
 
     #[doc(hidden)]
     /// this is cursed, but it's the only way to reset the lock data for the component without making the static mutable.

--- a/flecs_ecs/src/core/components/cached_ref.rs
+++ b/flecs_ecs/src/core/components/cached_ref.rs
@@ -7,13 +7,13 @@ use crate::sys;
 
 /// A reference to a component from a specific entity.
 /// Refs are a fast mechanism for referring to a specific entity/component
-pub struct CachedRef<'a, T: ComponentId> {
+pub struct CachedRef<'a, T: ComponentId + NotEmptyComponent> {
     world: WorldRef<'a>,
     component_ref: RefT,
     _marker: PhantomData<T>,
 }
 
-impl<'a, T: ComponentId> CachedRef<'a, T> {
+impl<'a, T: ComponentId + NotEmptyComponent> CachedRef<'a, T> {
     /// Create a new ref to a component.
     ///
     /// # Arguments

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -1603,7 +1603,11 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity::get_ref`
     #[doc(alias = "entity::get_ref")]
-    pub fn get_ref<T: ComponentId + NotEmptyComponent>(&self) -> CachedRef<'a, T::UnderlyingType> {
+    pub fn get_ref<T>(&self) -> CachedRef<'a, T::UnderlyingType>
+    where
+        T: ComponentId + NotEmptyComponent,
+        T::UnderlyingType: NotEmptyComponent,
+    {
         CachedRef::<T::UnderlyingType>::new(self.world, *self.id, T::get_id(self.world))
     }
 

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -889,7 +889,7 @@ impl<'a> EntityView<'a> {
         let id_data_id = unsafe { sys::ecs_get_typeid(world, id) };
 
         if data_id != id_data_id {
-            panic!("Data type does not match id type. For pairs this is the first element occurance that is not a ZST type.");
+            panic!("Data type does not match id type. For pairs this is the first element occurrence that is not a ZST type.");
         }
 
         set_helper(world, *self.id, data, id);
@@ -942,7 +942,7 @@ impl<'a> EntityView<'a> {
         let data_id = unsafe { sys::ecs_get_typeid(world_ptr, pair_id) };
 
         if data_id != first_id {
-            panic!("First type does not match id data type. For pairs this is the first element occurance that is not a ZST type.");
+            panic!("First type does not match id data type. For pairs this is the first element occurrence that is not a ZST type.");
         }
 
         set_helper(world_ptr, *self.id, first, pair_id);
@@ -970,7 +970,7 @@ impl<'a> EntityView<'a> {
         let data_id = unsafe { sys::ecs_get_typeid(world, pair_id) };
 
         if data_id != second_id {
-            panic!("Second type does not match id data type. For pairs this is the first element occurance that is not a ZST type.");
+            panic!("Second type does not match id data type. For pairs this is the first element occurrence that is not a ZST type.");
         }
 
         set_helper(world, *self.id, second, pair_id);

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -60,8 +60,18 @@ impl<'a> EntityView<'a> {
     #[doc(alias = "entity_builder::add")]
     pub fn add<T>(self) -> Self
     where
-        T: IntoComponentId + EmptyComponent,
+        T: IntoComponentId,
     {
+        const {
+            if !T::IS_TAGS {
+                if !T::First::IS_TAG && !T::First::IMPLS_DEFAULT {
+                    assert!(false, "Adding an element that is not a Tag / Zero sized type requires to implement Default");
+                }
+                if T::IS_PAIR && !T::Second::IS_TAG && !T::Second::IMPLS_DEFAULT {
+                    assert!(false, "Adding an element that is not a Tag / Zero sized type requires to implement Default");
+                }
+            }
+        }
         let world = self.world;
         unsafe { self.add_id_unchecked(T::get_id(world)) }
     }

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -796,6 +796,7 @@ impl<'a> EntityView<'a> {
         First: ComponentId,
         Second: ComponentId,
         (First, Second): FlecsCastType,
+        <(First, Second) as FlecsCastType>::CastType: NotEmptyComponent,
     {
         let id_pair = <(First, Second) as IntoComponentId>::get_id(self.world);
         self.auto_override_id(id_pair).set_id(data, id_pair)

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -66,16 +66,16 @@ impl<'a> EntityView<'a> {
     where
         T: IntoComponentId,
     {
-        const {
-            if !T::IS_TAGS {
-                if !T::First::IS_TAG && !T::First::IMPLS_DEFAULT {
-                    panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
-                }
-                if T::IS_PAIR && !T::Second::IS_TAG && !T::Second::IMPLS_DEFAULT {
-                    panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
-                }
-            }
-        }
+        // const {
+        //     if !T::IS_TAGS {
+        //         if !T::First::IS_TAG && !T::First::IMPLS_DEFAULT {
+        //             panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
+        //         }
+        //         if T::IS_PAIR && !T::Second::IS_TAG && !T::Second::IMPLS_DEFAULT {
+        //             panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
+        //         }
+        //     }
+        // }
         let world = self.world;
         unsafe { self.add_id_unchecked(T::get_id(world)) }
     }
@@ -126,11 +126,11 @@ impl<'a> EntityView<'a> {
     /// * C++ API: `entity_builder::add`
     #[doc(alias = "entity_builder::add")]
     pub fn add_first<First: ComponentId>(self, second: impl Into<Entity>) -> Self {
-        const {
-            if !First::IS_TAG && !First::IMPLS_DEFAULT {
-                panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
-            }
-        }
+        // const {
+        //     if !First::IS_TAG && !First::IMPLS_DEFAULT {
+        //         panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
+        //     }
+        // }
 
         let world = self.world;
         let world_ptr = world.world_ptr_mut();
@@ -212,11 +212,11 @@ impl<'a> EntityView<'a> {
         First: ComponentId,
         Second: ComponentId + ComponentType<Enum> + CachedEnumData,
     {
-        const {
-            if !First::IS_TAG && First::IMPLS_DEFAULT {
-                panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
-            }
-        }
+        // const {
+        //     if !First::IS_TAG && First::IMPLS_DEFAULT {
+        //         panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
+        //     }
+        // }
         let world = self.world;
         let enum_id = enum_value.get_id_variant(world);
         unsafe { self.add_id_unchecked((First::get_id(world), enum_id)) }
@@ -913,9 +913,9 @@ impl<'a> EntityView<'a> {
         Second: ComponentId,
         (First, Second): FlecsCastType,
     {
-        const {
-            assert!(!<(First, Second) as IntoComponentId>::IS_TAGS, "setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
-        };
+        // const {
+        //     assert!(!<(First, Second) as IntoComponentId>::IS_TAGS, "setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
+        // };
 
         set_helper(
             self.world.world_ptr_mut(),

--- a/flecs_ecs/src/core/entity_view/entity_view_mut.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_mut.rs
@@ -65,10 +65,10 @@ impl<'a> EntityView<'a> {
         const {
             if !T::IS_TAGS {
                 if !T::First::IS_TAG && !T::First::IMPLS_DEFAULT {
-                    assert!(false, "Adding an element that is not a Tag / Zero sized type requires to implement Default");
+                    panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
                 }
                 if T::IS_PAIR && !T::Second::IS_TAG && !T::Second::IMPLS_DEFAULT {
-                    assert!(false, "Adding an element that is not a Tag / Zero sized type requires to implement Default");
+                    panic!("Adding an element that is not a Tag / Zero sized type requires to implement Default");
                 }
             }
         }

--- a/flecs_ecs/src/core/flecs.rs
+++ b/flecs_ecs/src/core/flecs.rs
@@ -376,22 +376,26 @@ impl flecs_ecs::core::component_registration::registration_traits::ComponentId f
             std::sync::OnceLock::new();
         &ONCE_LOCK
     }
+
     fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
-        const NEEDS_DROP:bool =  <() as flecs_ecs::core::component_registration::registration_traits::ComponentInfo> ::NEEDS_DROP;
-        const IMPLS_CLONE: bool = <() as ComponentInfo>::IMPLS_CLONE;
-        const IMPLS_DEFAULT: bool = <() as ComponentInfo>::IMPLS_DEFAULT;
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<()>(type_hooks);
+    }
+
+    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+        const IMPLS_DEFAULT: bool = <() as ComponentInfo>::IMPLS_DEFAULT;
+
+        if IMPLS_DEFAULT {
+            flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,()>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >( type_hooks);
+        }
+    }
+
+    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+        const IMPLS_CLONE: bool = <() as ComponentInfo>::IMPLS_CLONE;
+
         if IMPLS_CLONE {
             flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,()>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type, >( type_hooks);
         } else {
             flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<()>(
-                type_hooks,
-            );
-        }
-        if IMPLS_DEFAULT {
-            flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,()>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >( type_hooks);
-        } else {
-            flecs_ecs::core::lifecycle_traits::register_ctor_panic_lifecycle_actions::<()>(
                 type_hooks,
             );
         }

--- a/flecs_ecs/src/core/get_tuple.rs
+++ b/flecs_ecs/src/core/get_tuple.rs
@@ -68,7 +68,7 @@ pub trait GetTupleTypeOperation {
 
 impl<T> GetTupleTypeOperation for &T
 where
-    T: FlecsCastType,
+    T: FlecsCastType + NotEmptyComponent,
 {
     type ActualType<'e> = &'e <T as FlecsCastType>::CastType;
     type OnlyType = T;
@@ -84,7 +84,7 @@ where
 
 impl<T> GetTupleTypeOperation for &mut T
 where
-    T: FlecsCastType,
+    T: FlecsCastType + NotEmptyComponent,
 {
     type ActualType<'e> = &'e mut <T as FlecsCastType>::CastType;
     type OnlyType = T;
@@ -100,7 +100,7 @@ where
 
 impl<T> GetTupleTypeOperation for Option<&T>
 where
-    T: FlecsCastType,
+    T: FlecsCastType + NotEmptyComponent,
 {
     type ActualType<'e> = Option<&'e <T as FlecsCastType>::CastType>;
     type OnlyType = T;
@@ -119,7 +119,7 @@ where
 
 impl<T> GetTupleTypeOperation for Option<&mut T>
 where
-    T: FlecsCastType,
+    T: FlecsCastType + NotEmptyComponent,
 {
     type ActualType<'e> = Option<&'e mut <T as FlecsCastType>::CastType>;
     type OnlyType = T;

--- a/flecs_ecs/src/core/iterable.rs
+++ b/flecs_ecs/src/core/iterable.rs
@@ -75,6 +75,7 @@ pub trait IterableTypeOperation {
     type ActualType<'w>;
     type SliceType<'w>;
     type OnlyType: ComponentId;
+    const ONE: i32 = 1;
 
     fn populate_term(term: &mut sys::ecs_term_t);
     fn create_tuple_data<'a>(array_components_data: *mut u8, index: usize) -> Self::ActualType<'a>;
@@ -344,6 +345,7 @@ pub trait Iterable: Sized {
     type Pointers: ComponentPointers<Self>;
     type TupleType<'a>;
     type TupleSliceType<'a>;
+    const COUNT: i32;
 
     fn create_ptrs(iter: &IterT) -> Self::Pointers {
         Self::Pointers::new(iter)
@@ -388,10 +390,11 @@ pub trait Iterable: Sized {
 impl<A> Iterable for A
 where
     A: IterableTypeOperation,
-{
+{ 
     type Pointers = ComponentsData<A, 1>;
     type TupleType<'w> = A::ActualType<'w>;
     type TupleSliceType<'w> = A::SliceType<'w>;
+    const COUNT : i32 = 1;
 
     fn populate<'a>(filter: &mut impl QueryBuilderImpl<'a>) {
         let id = <A::OnlyType as ComponentId>::get_id(filter.world());
@@ -627,7 +630,7 @@ macro_rules! impl_iterable {
                 $t::SliceType<'w>,
             )*);
             type Pointers = ComponentsData<Self, { tuple_count!($($t),*) }>;
-
+            const COUNT : i32 = tuple_count!($($t),*);
 
             fn populate<'a>(filter: &mut impl QueryBuilderImpl<'a>) {
                 let _world = filter.world();

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -225,7 +225,7 @@ impl<'a, P, T: Iterable> internals::QueryConfig<'a> for ObserverBuilder<'a, P, T
     }
 
     #[inline(always)]
-    fn count_generic_terms(&mut self) -> i32 {
+    fn count_generic_terms(&self) -> i32 {
         T::COUNT
     }
 }

--- a/flecs_ecs/src/core/observer_builder.rs
+++ b/flecs_ecs/src/core/observer_builder.rs
@@ -223,6 +223,11 @@ impl<'a, P, T: Iterable> internals::QueryConfig<'a> for ObserverBuilder<'a, P, T
     fn query_desc_mut(&mut self) -> &mut sys::ecs_query_desc_t {
         &mut self.desc.query
     }
+
+    #[inline(always)]
+    fn count_generic_terms(&mut self) -> i32 {
+        T::COUNT
+    }
 }
 impl<'a, P, T: Iterable> TermBuilderImpl<'a> for ObserverBuilder<'a, P, T> {}
 

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -295,6 +295,10 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
     /// * C++ API: `query_builder_i::expr`
     #[doc(alias = "query_builder_i::expr")]
     fn expr(&mut self, expr: &'a str) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
+
         let expr = format!("{}\0", expr);
 
         ecs_assert!(

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -161,6 +161,11 @@ impl<'a, T: Iterable> internals::QueryConfig<'a> for QueryBuilder<'a, T> {
     fn query_desc_mut(&mut self) -> &mut sys::ecs_query_desc_t {
         &mut self.desc
     }
+
+    #[inline(always)]
+    fn count_generic_terms(&mut self) -> i32 {
+        T::COUNT
+    }
 }
 
 impl<'a, T: Iterable> TermBuilderImpl<'a> for QueryBuilder<'a, T> {}

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -163,7 +163,7 @@ impl<'a, T: Iterable> internals::QueryConfig<'a> for QueryBuilder<'a, T> {
     }
 
     #[inline(always)]
-    fn count_generic_terms(&mut self) -> i32 {
+    fn count_generic_terms(&self) -> i32 {
         T::COUNT
     }
 }

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -329,7 +329,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.init_current_term(id);
         let current_term = self.current_term_mut();
         if current_term.inout == InOutKind::Default as i16 {
-            self.set_inout_none();
+            self.current_term_mut().inout = InOutKind::None as i16;
         }
         self
     }
@@ -377,11 +377,11 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
             let id = T::get_id(world);
             self.init_current_term(id);
             if T::First::IS_REF {
-                self.set_in();
+                self.current_term_mut().inout = InOutKind::In as i16;
             } else if T::First::IS_MUT {
-                self.set_inout();
+                self.current_term_mut().inout = InOutKind::InOut as i16;
             } else {
-                self.set_inout_none();
+                self.current_term_mut().inout = InOutKind::None as i16;
             }
         }
         self
@@ -464,7 +464,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.set_first_name(name);
         let term = self.current_term();
         if term.inout == InOutKind::Default as i16 {
-            self.set_inout_none();
+            self.current_term_mut().inout = InOutKind::None as i16;
         }
         self
     }
@@ -492,7 +492,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.set_second_name(second);
         let term = self.current_term();
         if term.inout == InOutKind::Default as i16 {
-            self.set_inout_none();
+            self.current_term_mut().inout = InOutKind::None as i16;
         }
         self
     }
@@ -503,7 +503,7 @@ pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {
         self.set_first_name(first).set_second_id(second.into());
         let term = self.current_term();
         if term.inout == InOutKind::Default as i16 {
-            self.set_inout_none();
+            self.current_term_mut().inout = InOutKind::None as i16;
         }
         self
     }

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -245,6 +245,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term::reset`
     #[doc(alias = "term::reset")]
     fn reset(&mut self) {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         // we don't for certain if this causes any side effects not using the nullptr and just using the default value.
         // if it does we can use Option.
         let term = self.current_term_mut();
@@ -355,6 +358,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::id`
     #[doc(alias = "term_builder_i::id")]
     fn set_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         let term_ref = self.term_ref_mut();
         term_ref.id = *id.into();
         self
@@ -377,6 +383,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::entity`
     #[doc(alias = "term_builder_i::entity")]
     fn entity(&mut self, entity: impl Into<Entity>) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.term_ref_mut().id = *entity.into() | ECS_IS_ENTITY;
         self
     }
@@ -392,6 +401,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::name`
     #[doc(alias = "term_builder_i::name")]
     fn name(&mut self, name: &'a str) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         let name = format!("{}\0", name);
         let term_ref = self.term_ref_mut();
         term_ref.name = name.as_ptr() as *mut i8;
@@ -416,6 +428,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::var`
     #[doc(alias = "term_builder_i::var")]
     fn set_var(&mut self, var_name: &'a str) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         let var_name = format!("{}\0", var_name);
 
         let term_ref = self.term_ref_mut();
@@ -441,6 +456,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::flags`
     #[doc(alias = "term_builder_i::flags")]
     fn flags(&mut self, flags: u64) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.term_ref_mut().id = flags;
         self
     }
@@ -452,6 +470,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn src(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_term_ref_mode(TermRefMode::Src);
         self
     }
@@ -465,6 +486,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn first(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_term_ref_mode(TermRefMode::First);
         self
     }
@@ -477,6 +501,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::second`
     #[doc(alias = "term_builder_i::second")]
     fn second(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_term_ref_mode(TermRefMode::Second);
         self
     }
@@ -492,6 +519,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.src().set_id(id)
     }
 
@@ -506,6 +536,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src<T: ComponentId>(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_src_id(T::get_id(self.world()))
     }
 
@@ -521,6 +554,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src_name(&mut self, name: &'a str) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         ecs_assert!(
             !name.is_empty(),
             FlecsErrorCode::InvalidParameter,
@@ -546,6 +582,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn set_first_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.first().set_id(id)
     }
 
@@ -560,6 +599,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn set_first<T: ComponentId>(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_first_id(T::get_id(self.world()))
     }
 
@@ -575,6 +617,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn set_first_name(&mut self, name: &'a str) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         ecs_assert!(
             !name.is_empty(),
             FlecsErrorCode::InvalidParameter,
@@ -600,6 +645,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::second`
     #[doc(alias = "term_builder_i::second")]
     fn set_second_id(&mut self, id: impl Into<Entity>) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.second().set_id(id)
     }
 
@@ -614,6 +662,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::second`
     #[doc(alias = "term_builder_i::second")]
     fn set_second<T: ComponentId>(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_second_id(T::get_id(self.world()))
     }
 
@@ -809,6 +860,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::inout`
     #[doc(alias = "term_builder_i::inout")]
     fn set_inout_kind(&mut self, inout: InOutKind) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.current_term_mut().inout = inout.into();
         self
     }
@@ -830,6 +884,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::inout_stage`
     #[doc(alias = "term_builder_i::inout_stage")]
     fn inout_stage(&mut self, inout: InOutKind) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.set_inout_kind(inout);
         if self.current_term_mut().oper != OperKind::Not as i16 {
             self.src().entity(0);
@@ -850,6 +907,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::write")]
     #[inline(always)]
     fn write_curr(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.inout_stage(InOutKind::Out)
     }
 
@@ -865,6 +925,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::read")]
     #[inline(always)]
     fn read_curr(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.inout_stage(InOutKind::In)
     }
 
@@ -879,6 +942,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::read_write")]
     #[inline(always)]
     fn read_write(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.inout_stage(InOutKind::InOut)
     }
 
@@ -892,6 +958,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::in")]
     #[inline(always)]
     fn set_in(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. use &T instead")
+        }
         self.set_inout_kind(InOutKind::In)
     }
 
@@ -905,6 +974,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::out")]
     #[inline(always)]
     fn set_out(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. Use &mut T instead.")
+        }
         self.set_inout_kind(InOutKind::Out)
     }
 
@@ -918,6 +990,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::inout")]
     #[inline(always)]
     fn set_inout(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. Use &mut T instead.")
+        }
         self.set_inout_kind(InOutKind::InOut)
     }
 
@@ -931,6 +1006,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::inout_none")]
     #[inline(always)]
     fn set_inout_none(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_inout_kind(InOutKind::None)
     }
 
@@ -946,6 +1024,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::oper")]
     #[inline(always)]
     fn set_oper(&mut self, oper: OperKind) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. ")
+        }
         self.current_term_mut().oper = oper as i16;
         self
     }
@@ -960,6 +1041,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::and")]
     #[inline(always)]
     fn and(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_oper(OperKind::And)
     }
 
@@ -973,6 +1057,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::or")]
     #[inline(always)]
     fn or(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_oper(OperKind::Or)
     }
 
@@ -987,6 +1074,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[allow(clippy::should_implement_trait)]
     #[inline(always)]
     fn not(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_oper(OperKind::Not)
     }
 
@@ -1000,6 +1090,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::optional")]
     #[inline(always)]
     fn optional(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature. Use Option<> instead.")
+        }
         self.set_oper(OperKind::Optional)
     }
 
@@ -1013,6 +1106,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::and_from")]
     #[inline(always)]
     fn and_from(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_oper(OperKind::AndFrom)
     }
 
@@ -1026,6 +1122,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::or_from")]
     #[inline(always)]
     fn or_from(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_oper(OperKind::OrFrom)
     }
 
@@ -1039,6 +1138,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::not_from")]
     #[inline(always)]
     fn not_from(&mut self) -> &mut Self {
+        if self.current_term_index() < self.count_generic_terms() {
+            panic!("This function should only be used on terms that are not part of the generic type signature.")
+        }
         self.set_oper(OperKind::NotFrom)
     }
 

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -84,7 +84,7 @@ pub mod internals {
         fn query_desc(&self) -> &sys::ecs_query_desc_t;
         fn query_desc_mut(&mut self) -> &mut sys::ecs_query_desc_t;
 
-        fn count_generic_terms(&mut self) -> i32;
+        fn count_generic_terms(&self) -> i32;
 
         #[inline(always)]
         fn current_term_ref_mode(&self) -> TermRefMode {
@@ -156,6 +156,11 @@ pub mod internals {
     }
 }
 
+fn check_term_access_validity(term: &impl TermBuilderImpl<'a>) {
+    if term.current_term_index() < term.count_generic_terms() {
+        panic!("This function should only be used on terms that are not part of the generic type signature. ")
+    }
+}
 /// Term builder interface.
 /// A term is a single element of a query expression.
 pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a> {
@@ -245,9 +250,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term::reset`
     #[doc(alias = "term::reset")]
     fn reset(&mut self) {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         // we don't for certain if this causes any side effects not using the nullptr and just using the default value.
         // if it does we can use Option.
         let term = self.current_term_mut();
@@ -358,9 +362,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::id`
     #[doc(alias = "term_builder_i::id")]
     fn set_id(&mut self, id: impl Into<Entity>) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         let term_ref = self.term_ref_mut();
         term_ref.id = *id.into();
         self
@@ -383,9 +386,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::entity`
     #[doc(alias = "term_builder_i::entity")]
     fn entity(&mut self, entity: impl Into<Entity>) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         self.term_ref_mut().id = *entity.into() | ECS_IS_ENTITY;
         self
     }
@@ -401,9 +403,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::name`
     #[doc(alias = "term_builder_i::name")]
     fn name(&mut self, name: &'a str) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         let name = format!("{}\0", name);
         let term_ref = self.term_ref_mut();
         term_ref.name = name.as_ptr() as *mut i8;
@@ -428,9 +429,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::var`
     #[doc(alias = "term_builder_i::var")]
     fn set_var(&mut self, var_name: &'a str) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         let var_name = format!("{}\0", var_name);
 
         let term_ref = self.term_ref_mut();
@@ -456,9 +456,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::flags`
     #[doc(alias = "term_builder_i::flags")]
     fn flags(&mut self, flags: u64) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         self.term_ref_mut().id = flags;
         self
     }
@@ -470,9 +469,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn src(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         self.set_term_ref_mode(TermRefMode::Src);
         self
     }
@@ -486,9 +484,8 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn first(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
+
         self.set_term_ref_mode(TermRefMode::First);
         self
     }
@@ -501,9 +498,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::second`
     #[doc(alias = "term_builder_i::second")]
     fn second(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.set_term_ref_mode(TermRefMode::Second);
         self
     }
@@ -519,9 +514,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src_id(&mut self, id: impl Into<Entity>) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.src().set_id(id)
     }
 
@@ -536,9 +529,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src<T: ComponentId>(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.set_src_id(T::get_id(self.world()))
     }
 
@@ -554,9 +545,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src_name(&mut self, name: &'a str) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         ecs_assert!(
             !name.is_empty(),
             FlecsErrorCode::InvalidParameter,
@@ -582,9 +571,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn set_first_id(&mut self, id: impl Into<Entity>) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.first().set_id(id)
     }
 
@@ -599,9 +586,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn set_first<T: ComponentId>(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.set_first_id(T::get_id(self.world()))
     }
 
@@ -617,9 +602,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::first`
     #[doc(alias = "term_builder_i::first")]
     fn set_first_name(&mut self, name: &'a str) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         ecs_assert!(
             !name.is_empty(),
             FlecsErrorCode::InvalidParameter,
@@ -645,9 +628,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::second`
     #[doc(alias = "term_builder_i::second")]
     fn set_second_id(&mut self, id: impl Into<Entity>) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.second().set_id(id)
     }
 
@@ -662,9 +643,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::second`
     #[doc(alias = "term_builder_i::second")]
     fn set_second<T: ComponentId>(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.set_second_id(T::get_id(self.world()))
     }
 
@@ -860,9 +839,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::inout`
     #[doc(alias = "term_builder_i::inout")]
     fn set_inout_kind(&mut self, inout: InOutKind) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.current_term_mut().inout = inout.into();
         self
     }
@@ -884,9 +861,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::inout_stage`
     #[doc(alias = "term_builder_i::inout_stage")]
     fn inout_stage(&mut self, inout: InOutKind) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.set_inout_kind(inout);
         if self.current_term_mut().oper != OperKind::Not as i16 {
             self.src().entity(0);
@@ -907,9 +882,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::write")]
     #[inline(always)]
     fn write_curr(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.inout_stage(InOutKind::Out)
     }
 
@@ -925,9 +898,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::read")]
     #[inline(always)]
     fn read_curr(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.inout_stage(InOutKind::In)
     }
 
@@ -942,9 +913,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::read_write")]
     #[inline(always)]
     fn read_write(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.inout_stage(InOutKind::InOut)
     }
 
@@ -1006,9 +975,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::inout_none")]
     #[inline(always)]
     fn set_inout_none(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_inout_kind(InOutKind::None)
     }
 
@@ -1024,9 +991,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::oper")]
     #[inline(always)]
     fn set_oper(&mut self, oper: OperKind) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature. ")
-        }
+        check_term_access_validity(self);
         self.current_term_mut().oper = oper as i16;
         self
     }
@@ -1041,9 +1006,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::and")]
     #[inline(always)]
     fn and(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_oper(OperKind::And)
     }
 
@@ -1057,9 +1020,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::or")]
     #[inline(always)]
     fn or(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_oper(OperKind::Or)
     }
 
@@ -1074,9 +1035,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[allow(clippy::should_implement_trait)]
     #[inline(always)]
     fn not(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_oper(OperKind::Not)
     }
 
@@ -1106,9 +1065,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::and_from")]
     #[inline(always)]
     fn and_from(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_oper(OperKind::AndFrom)
     }
 
@@ -1122,9 +1079,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::or_from")]
     #[inline(always)]
     fn or_from(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_oper(OperKind::OrFrom)
     }
 
@@ -1138,9 +1093,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term_builder_i::not_from")]
     #[inline(always)]
     fn not_from(&mut self) -> &mut Self {
-        if self.current_term_index() < self.count_generic_terms() {
-            panic!("This function should only be used on terms that are not part of the generic type signature.")
-        }
+        check_term_access_validity(self);
         self.set_oper(OperKind::NotFrom)
     }
 

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -156,7 +156,7 @@ pub mod internals {
     }
 }
 
-fn check_term_access_validity(term: &impl TermBuilderImpl<'a>) {
+fn check_term_access_validity<'a>(term: &impl TermBuilderImpl<'a>) {
     if term.current_term_index() < term.count_generic_terms() {
         panic!("This function should only be used on terms that are not part of the generic type signature. ")
     }
@@ -362,7 +362,9 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::id`
     #[doc(alias = "term_builder_i::id")]
     fn set_id(&mut self, id: impl Into<Entity>) -> &mut Self {
-        check_term_access_validity(self);
+        if self.current_term_ref_mode() != TermRefMode::Src {
+            check_term_access_validity(self);
+        }
 
         let term_ref = self.term_ref_mut();
         term_ref.id = *id.into();
@@ -403,8 +405,6 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::name`
     #[doc(alias = "term_builder_i::name")]
     fn name(&mut self, name: &'a str) -> &mut Self {
-        check_term_access_validity(self);
-
         let name = format!("{}\0", name);
         let term_ref = self.term_ref_mut();
         term_ref.name = name.as_ptr() as *mut i8;
@@ -469,8 +469,6 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn src(&mut self) -> &mut Self {
-        check_term_access_validity(self);
-
         self.set_term_ref_mode(TermRefMode::Src);
         self
     }
@@ -514,7 +512,6 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src_id(&mut self, id: impl Into<Entity>) -> &mut Self {
-        check_term_access_validity(self);
         self.src().set_id(id)
     }
 
@@ -529,7 +526,6 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src<T: ComponentId>(&mut self) -> &mut Self {
-        check_term_access_validity(self);
         self.set_src_id(T::get_id(self.world()))
     }
 
@@ -545,7 +541,6 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     /// * C++ API: `term_builder_i::src`
     #[doc(alias = "term_builder_i::src")]
     fn set_src_name(&mut self, name: &'a str) -> &mut Self {
-        check_term_access_validity(self);
         ecs_assert!(
             !name.is_empty(),
             FlecsErrorCode::InvalidParameter,

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -84,6 +84,8 @@ pub mod internals {
         fn query_desc(&self) -> &sys::ecs_query_desc_t;
         fn query_desc_mut(&mut self) -> &mut sys::ecs_query_desc_t;
 
+        fn count_generic_terms(&mut self) -> i32;
+
         #[inline(always)]
         fn current_term_ref_mode(&self) -> TermRefMode {
             self.term_builder().term_ref_mode

--- a/flecs_ecs/src/core/utility/traits/into_world.rs
+++ b/flecs_ecs/src/core/utility/traits/into_world.rs
@@ -45,6 +45,8 @@ pub struct WorldRef<'a> {
     _marker: PhantomData<&'a ()>,
 }
 
+unsafe impl<'a> Send for WorldRef<'a> {}
+
 impl<'a> WorldRef<'a> {
     #[inline(always)]
     pub fn real_world(&self) -> WorldRef<'a> {

--- a/flecs_ecs/src/core/utility/traits/iter.rs
+++ b/flecs_ecs/src/core/utility/traits/iter.rs
@@ -513,7 +513,7 @@ where
     /// Run iterator with each forwarding.
     /// The "iter" iterator accepts a function that is invoked for each matching
     /// table. The following function signature is valid:
-    ///  - func: (it: &mut Iter) + func_each: (comp1 : &mut T1, comp2 : &mut T2, ...)
+    ///  - `func`: (it: &mut Iter) + `func_each`: (comp1 : &mut T1, comp2 : &mut T2, ...)
     ///
     /// allows for more control over how entities
     /// are iterated as it provides multiple entities in the same callback
@@ -611,7 +611,7 @@ where
     ///
     /// The "iter" iterator accepts a function that is invoked for each matching
     /// table. The following function signature is valid:
-    /// - func: (it: &mut Iter) + func_each: (entity: Entity, comp1 : &mut T1, comp2 : &mut T2, ...)
+    /// - `func`: (it: &mut Iter) + `func_each`: (entity: Entity, comp1 : &mut T1, comp2 : &mut T2, ...)
     ///
     /// allows for more control over how entities
     /// are iterated as it provides multiple entities in the same callback

--- a/flecs_ecs/src/core/utility/traits/mod.rs
+++ b/flecs_ecs/src/core/utility/traits/mod.rs
@@ -22,7 +22,7 @@ use crate::core::{ImplementsClone, ImplementsDefault};
 pub mod private {
     use crate::core::*;
     use crate::sys;
-    use std::{ffi::c_void, ptr};
+    use std::ffi::c_void;
 
     #[allow(non_camel_case_types)]
     #[doc(hidden)]
@@ -31,9 +31,19 @@ pub mod private {
         T: Iterable,
         P: ComponentId,
     {
-        fn set_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self;
+        fn set_callback_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self;
 
-        fn set_binding_context_free(&mut self, binding_ctx_free: sys::ecs_ctx_free_t) -> &mut Self;
+        fn set_callback_binding_context_free(
+            &mut self,
+            binding_ctx_free: sys::ecs_ctx_free_t,
+        ) -> &mut Self;
+
+        fn set_run_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self;
+
+        fn set_run_binding_context_free(
+            &mut self,
+            run_ctx_free: flecs_ecs_sys::ecs_ctx_free_t,
+        ) -> &mut Self;
 
         fn desc_binding_context(&self) -> *mut c_void;
 
@@ -41,6 +51,8 @@ pub mod private {
             &mut self,
             callback: Option<unsafe extern "C" fn(*mut sys::ecs_iter_t)>,
         );
+
+        fn set_desc_run(&mut self, callback: Option<unsafe extern "C" fn(*mut sys::ecs_iter_t)>);
 
         /// Callback of the each functionality
         ///
@@ -51,7 +63,7 @@ pub mod private {
         /// # See also
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
-        unsafe extern "C" fn run_each<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_each<const CALLED_FROM_RUN: bool, Func>(iter: *mut IterT)
         where
             Func: FnMut(T::TupleType<'_>),
         {
@@ -65,9 +77,7 @@ pub mod private {
                 "used to assert if using .field() in each functions."
             );
 
-            let ctx: *mut ObserverSystemBindingCtx = (*iter).callback_ctx as *mut _;
-            let each = (*ctx).each.unwrap();
-            let each = &mut *(each as *mut Func);
+            let each = &mut *((*iter).callback_ctx as *mut Func);
 
             let mut components_data = T::create_ptrs(&*iter);
             let iter_count = {
@@ -78,14 +88,18 @@ pub mod private {
                 }
             };
 
-            sys::ecs_table_lock((*iter).world, (*iter).table);
+            if !CALLED_FROM_RUN {
+                sys::ecs_table_lock((*iter).world, (*iter).table);
+            }
 
             for i in 0..iter_count {
                 let tuple = components_data.get_tuple(i);
                 each(tuple);
             }
 
-            sys::ecs_table_unlock((*iter).world, (*iter).table);
+            if !CALLED_FROM_RUN {
+                sys::ecs_table_unlock((*iter).world, (*iter).table);
+            }
         }
 
         /// Callback of the `each_entity` functionality
@@ -98,8 +112,9 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn run_each_entity<Func>(iter: *mut IterT)
-        where
+        unsafe extern "C" fn execute_each_entity<const CALLED_FROM_RUN: bool, Func>(
+            iter: *mut IterT,
+        ) where
             Func: FnMut(EntityView, T::TupleType<'_>),
         {
             ecs_assert!(
@@ -112,9 +127,7 @@ pub mod private {
                 "used to assert if using .field() in each functions."
             );
 
-            let ctx: *mut ObserverSystemBindingCtx = (*iter).callback_ctx as *mut _;
-            let each_entity = (*ctx).each_entity.unwrap();
-            let each_entity = &mut *(each_entity as *mut Func);
+            let each_entity = &mut *((*iter).callback_ctx as *mut Func);
 
             let mut components_data = T::create_ptrs(&*iter);
             let iter_count = {
@@ -125,7 +138,9 @@ pub mod private {
                 }
             };
 
-            sys::ecs_table_lock((*iter).world, (*iter).table);
+            if !CALLED_FROM_RUN {
+                sys::ecs_table_lock((*iter).world, (*iter).table);
+            }
 
             for i in 0..iter_count {
                 let world = WorldRef::from_ptr((*iter).world);
@@ -134,7 +149,10 @@ pub mod private {
 
                 each_entity(entity, tuple);
             }
-            sys::ecs_table_unlock((*iter).world, (*iter).table);
+
+            if !CALLED_FROM_RUN {
+                sys::ecs_table_unlock((*iter).world, (*iter).table);
+            }
         }
 
         /// Callback of the `each_iter` functionality
@@ -147,9 +165,9 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn run_each_iter<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_each_iter<Func>(iter: *mut IterT)
         where
-            Func: FnMut(Iter<P>, usize, T::TupleType<'_>),
+            Func: FnMut(Iter<false, P>, usize, T::TupleType<'_>),
         {
             ecs_assert!(
                 {
@@ -161,9 +179,7 @@ pub mod private {
                 "used to assert if using .field() in each functions."
             );
 
-            let ctx: *mut ObserverSystemBindingCtx = (*iter).callback_ctx as *mut _;
-            let each_iter = (*ctx).each_iter.unwrap();
-            let each_iter = &mut *(each_iter as *mut Func);
+            let each_iter = &mut *((*iter).callback_ctx as *mut Func);
 
             let mut components_data = T::create_ptrs(&*iter);
             let iter_count = {
@@ -195,30 +211,20 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn run_iter_only<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_run<Func>(iter: *mut IterT)
         where
-            Func: FnMut(Iter<P>),
+            Func: FnMut(Iter<true, P>),
         {
             unsafe {
-                let ctx: *mut ObserverSystemBindingCtx = (*iter).callback_ctx as *mut _;
-                let iter_only = (*ctx).iter_only.unwrap();
-                let iter_only = &mut *(iter_only as *mut Func);
-                let iter_count = {
-                    if (*iter).count == 0 {
-                        1_usize
-                    } else {
-                        (*iter).count as usize
-                    }
-                };
-
-                sys::ecs_table_lock((*iter).world, (*iter).table);
-
-                for _ in 0..iter_count {
-                    let iter_t = Iter::new(&mut *iter);
-                    iter_only(iter_t);
-                }
-
-                sys::ecs_table_unlock((*iter).world, (*iter).table);
+                let run = &mut *((*iter).run_ctx as *mut Func);
+                let mut iter_t = Iter::new(&mut *iter);
+                iter_t.iter_mut().flags &= !sys::EcsIterIsValid;
+                run(iter_t);
+                // ecs_assert!(
+                //     (*iter).flags & sys::EcsIterIsValid == 0,
+                //     FlecsErrorCode::InvalidOperation,
+                //     "iterators must be manually finished with ecs_iter_fini"
+                // );
             }
         }
 
@@ -232,13 +238,11 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn run_iter<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_run_iter<Func>(iter: *mut IterT)
         where
-            Func: FnMut(Iter<P>, T::TupleSliceType<'_>),
+            Func: FnMut(Iter<false, P>, T::TupleSliceType<'_>),
         {
-            let ctx: *mut ObserverSystemBindingCtx = (*iter).callback_ctx as *mut _;
-            let iter_func = (*ctx).iter.unwrap();
-            let iter_func = &mut *(iter_func as *mut Func);
+            let run_iter = &mut *((*iter).callback_ctx as *mut Func);
 
             let mut components_data = T::create_ptrs(&*iter);
             let iter_count = {
@@ -253,72 +257,42 @@ pub mod private {
 
             let tuple = components_data.get_slice(iter_count);
             let iter_t = Iter::new(&mut *iter);
-            iter_func(iter_t, tuple);
+            run_iter(iter_t, tuple);
             sys::ecs_table_unlock((*iter).world, (*iter).table);
         }
 
-        // free functions
-
-        extern "C" fn on_free_each(ptr: *mut c_void) {
-            let ptr_func: *mut fn(T::TupleType<'_>) = ptr as *mut fn(T::TupleType<'_>);
+        extern "C" fn free_callback<Func>(ptr: *mut c_void) {
             unsafe {
-                ptr::drop_in_place(ptr_func);
-            }
+                drop(Box::from_raw(ptr as *mut Func));
+            };
         }
 
-        extern "C" fn on_free_each_entity(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&mut EntityView, T::TupleType<'_>) =
-                ptr as *mut fn(&mut EntityView, T::TupleType<'_>);
-            unsafe {
-                ptr::drop_in_place(ptr_func);
-            }
-        }
+        // /// Get the binding context
+        // fn get_binding_context(&mut self, is_run: bool) -> &mut ReactorBindingType {
+        //     let mut binding_ctx: *mut ReactorBindingType = self.desc_binding_context() as *mut _;
 
-        extern "C" fn on_free_each_iter(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&mut Iter<P>, usize, T::TupleType<'_>) =
-                ptr as *mut fn(&mut Iter<P>, usize, T::TupleType<'_>);
-            unsafe {
-                ptr::drop_in_place(ptr_func);
-            }
-        }
+        //     if binding_ctx.is_null() {
+        //         let new_binding_ctx = Box::<ReactorBindingType>::default();
+        //         let static_ref = Box::leak(new_binding_ctx);
+        //         binding_ctx = static_ref;
+        //         if is_run {
+        //             self.set_run_binding_context(binding_ctx as *mut c_void);
+        //             self.set_run_binding_context_free(Some(Self::binding_ctx_drop));
+        //         } else {
+        //             self.set_callback_binding_context(binding_ctx as *mut c_void);
+        //             self.set_callback_binding_context_free(Some(Self::binding_ctx_drop));
+        //         }
+        //     }
+        //     unsafe { &mut *binding_ctx }
+        // }
 
-        extern "C" fn on_free_iter_only(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&Iter<P>) = ptr as *mut fn(&Iter<P>);
-            unsafe {
-                ptr::drop_in_place(ptr_func);
-            }
-        }
-
-        extern "C" fn on_free_iter(ptr: *mut c_void) {
-            let ptr_func: *mut fn(&Iter<P>, T::TupleSliceType<'_>) =
-                ptr as *mut fn(&Iter<P>, T::TupleSliceType<'_>);
-            unsafe {
-                ptr::drop_in_place(ptr_func);
-            }
-        }
-
-        /// Get the binding context
-        fn get_binding_context(&mut self) -> &mut ObserverSystemBindingCtx {
-            let mut binding_ctx: *mut ObserverSystemBindingCtx =
-                self.desc_binding_context() as *mut _;
-
-            if binding_ctx.is_null() {
-                let new_binding_ctx = Box::<ObserverSystemBindingCtx>::default();
-                let static_ref = Box::leak(new_binding_ctx);
-                binding_ctx = static_ref;
-                self.set_binding_context(binding_ctx as *mut c_void);
-                self.set_binding_context_free(Some(Self::binding_ctx_drop));
-            }
-            unsafe { &mut *binding_ctx }
-        }
-
-        /// drop the binding context
-        extern "C" fn binding_ctx_drop(ptr: *mut c_void) {
-            let ptr_struct: *mut ObserverSystemBindingCtx = ptr as *mut ObserverSystemBindingCtx;
-            unsafe {
-                ptr::drop_in_place(ptr_struct);
-            }
-        }
+        // /// drop the binding context
+        // extern "C" fn binding_ctx_drop(ptr: *mut c_void) {
+        //     let ptr_struct: *mut ReactorBindingType = ptr as *mut ReactorBindingType;
+        //     unsafe {
+        //         ptr::drop_in_place(ptr_struct);
+        //     }
+        // }
     }
 }
 

--- a/flecs_ecs/src/core/utility/traits/reactor.rs
+++ b/flecs_ecs/src/core/utility/traits/reactor.rs
@@ -270,7 +270,7 @@ where
     ///
     /// The "iter" iterator accepts a function that is invoked for each matching
     /// table. The following function signature is valid:
-    ///  - func: (it: &mut Iter) + func_each: (comp1 : &mut T1, comp2 : &mut T2, ...)
+    ///  - `func`: (it: &mut Iter) + `func_each`: (comp1 : &mut T1, comp2 : &mut T2, ...)
     ///
     /// allows for more control over how entities
     /// are iterated as it provides multiple entities in the same callback
@@ -387,7 +387,7 @@ where
     ///
     /// The "iter" iterator accepts a function that is invoked for each matching
     /// table. The following function signature is valid:
-    /// - func: (it: &mut Iter) + func_each_entity: (entity: EntityView, comp1 : &mut T1, comp2 : &mut T2, ...)
+    /// - `func`: (it: &mut Iter) + `func_each_entity`: (entity: `EntityView`, comp1 : &mut T1, comp2 : &mut T2, ...)
     ///
     /// allows for more control over how entities
     /// are iterated as it provides multiple entities in the same callback

--- a/flecs_ecs/src/core/utility/traits/reactor.rs
+++ b/flecs_ecs/src/core/utility/traits/reactor.rs
@@ -7,19 +7,6 @@ where
     T: Iterable,
     P: ComponentId,
 {
-    /// Set action / ctx
-    ///
-    /// # Arguments
-    ///
-    /// * `callback` - the callback to set
-    ///
-    /// # See also
-    ///
-    /// * C++ API: `system_builder_i::run`
-    #[doc(alias = "system_builder_i::ctx")]
-    #[doc(alias = "observer_builder_i::ctx")]
-    fn set_run_callback(&mut self, callback: ecs_iter_action_t) -> &mut Self;
-
     //fn set_instanced(&mut self, instanced: bool);
 
     /// Set context
@@ -36,15 +23,14 @@ where
     where
         Func: FnMut(T::TupleType<'_>) + 'static,
     {
-        let binding_ctx = self.get_binding_context();
-
         let each_func = Box::new(func);
         let each_static_ref = Box::leak(each_func);
 
-        binding_ctx.each = Some(each_static_ref as *mut _ as *mut c_void);
-        binding_ctx.free_each = Some(Self::on_free_each);
-
-        self.set_desc_callback(Some(Self::run_each::<Func> as unsafe extern "C" fn(_)));
+        self.set_callback_binding_context(each_static_ref as *mut _ as *mut c_void);
+        self.set_callback_binding_context_free(Some(Self::free_callback::<Func>));
+        self.set_desc_callback(Some(
+            Self::execute_each::<false, Func> as unsafe extern "C" fn(_),
+        ));
 
         //self.set_instanced(true);
 
@@ -55,16 +41,13 @@ where
     where
         Func: FnMut(EntityView, T::TupleType<'_>) + 'static,
     {
-        let binding_ctx = self.get_binding_context();
-
         let each_entity_func = Box::new(func);
         let each_entity_static_ref = Box::leak(each_entity_func);
 
-        binding_ctx.each_entity = Some(each_entity_static_ref as *mut _ as *mut c_void);
-        binding_ctx.free_each_entity = Some(Self::on_free_each_entity);
-
+        self.set_callback_binding_context(each_entity_static_ref as *mut _ as *mut c_void);
+        self.set_callback_binding_context_free(Some(Self::free_callback::<Func>));
         self.set_desc_callback(Some(
-            Self::run_each_entity::<Func> as unsafe extern "C" fn(_),
+            Self::execute_each_entity::<false, Func> as unsafe extern "C" fn(_),
         ));
 
         //self.set_instanced(true);
@@ -74,55 +57,444 @@ where
 
     fn each_iter<Func>(&mut self, func: Func) -> <Self as builder::Builder<'a>>::BuiltType
     where
-        Func: FnMut(Iter<P>, usize, T::TupleType<'_>) + 'static,
+        Func: FnMut(Iter<false, P>, usize, T::TupleType<'_>) + 'static,
     {
-        let binding_ctx = self.get_binding_context();
-
         let each_iter_func = Box::new(func);
         let each_iter_static_ref = Box::leak(each_iter_func);
 
-        binding_ctx.each_iter = Some(each_iter_static_ref as *mut _ as *mut c_void);
-        binding_ctx.free_each_iter = Some(Self::on_free_each_iter);
+        self.set_callback_binding_context(each_iter_static_ref as *mut _ as *mut c_void);
+        self.set_callback_binding_context_free(Some(Self::free_callback::<Func>));
 
-        self.set_desc_callback(Some(Self::run_each_iter::<Func> as unsafe extern "C" fn(_)));
+        self.set_desc_callback(Some(
+            Self::execute_each_iter::<Func> as unsafe extern "C" fn(_),
+        ));
 
         //self.set_instanced(true);
 
         self.build()
     }
 
-    fn iter_only<Func>(&mut self, func: Func) -> <Self as builder::Builder<'a>>::BuiltType
+    /// Run iterator. This operation expects manual iteration over the tables with `iter.next_iter()` and `iter.iter()`.
+    ///
+    /// The "run" iterator accepts a function that is invoked for each matching
+    /// table. The following function signature is valid:
+    ///  - func(it: &mut Iter)
+    ///
+    /// allows for more control over how entities
+    /// are iterated as it provides multiple entities in the same callback
+    /// and allows to determine what should happen before and past iteration.
+    ///
+    /// Iter iterators are not automatically instanced. When a result contains
+    /// shared components, entities of the result will be iterated one by one.
+    /// This ensures that applications can't accidentally read out of bounds by
+    /// accessing a shared component as an array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::{rc::Rc, cell::RefCell};
+    /// use flecs_ecs::prelude::*;
+    ///
+    /// #[derive(Component, Debug)]
+    /// struct Tag;
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Position {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Velocity {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// let world = World::new();
+    ///
+    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add::<Tag>().add::<Position>();
+    /// world
+    ///     .entity()
+    ///     .add::<Tag>()
+    ///     .add::<Position>()
+    ///     .add::<Velocity>();
+    ///
+    /// let count_entities = Rc::new(RefCell::new(0));
+    /// let count_tables = Rc::new(RefCell::new(0));
+    /// // Clone the `Rc` to retain shared ownership and move it into the closure to satisfy the 'static lifetime requirement.
+    /// let count_entities_ref = count_entities.clone();
+    /// let count_tables_ref = count_tables.clone();
+    ///
+    /// let system = world.system::<(&Tag, &Position)>().run(move |mut it| {
+    ///     println!("start operations");
+    ///     while it.next_iter() {
+    ///         *count_tables_ref.borrow_mut() += 1;
+    ///         let pos = it.field::<&Position>(1).unwrap(); //at index 1 in (&Tag, &Position)
+    ///         for i in it.iter() {
+    ///             *count_entities_ref.borrow_mut() += 1;
+    ///             let entity = it.entity(i);
+    ///             println!("{:?}: {:?}", entity, pos[i]);
+    ///         }
+    ///     }
+    ///     println!("end operations");
+    /// });
+    ///
+    /// system.run();
+    ///
+    /// assert_eq!(*count_tables.borrow(), 2);
+    /// assert_eq!(*count_entities.borrow(), 3);
+    ///
+    /// // Output:
+    /// //  start operations
+    /// //  Entity name:  -- id: 508 -- archetype: flecs_ecs.main.Tag, flecs_ecs.main.Position: Position { x: 0, y: 0 }
+    /// //  Entity name:  -- id: 511 -- archetype: flecs_ecs.main.Tag, flecs_ecs.main.Position: Position { x: 0, y: 0 }
+    /// //  Entity name:  -- id: 512 -- archetype: flecs_ecs.main.Tag, flecs_ecs.main.Position, flecs_ecs.main.Velocity: Position { x: 0, y: 0 }
+    /// //  end operations
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `iterable::run`
+    #[doc(alias = "iterable::run")]
+    fn run<Func>(&mut self, func: Func) -> <Self as builder::Builder<'a>>::BuiltType
     where
-        Func: FnMut(Iter<P>) + 'static,
+        Func: FnMut(Iter<true, P>) + 'static,
     {
-        let binding_ctx = self.get_binding_context();
+        let run = Box::new(func);
+        let run_static_ref = Box::leak(run);
+
+        self.set_run_binding_context(run_static_ref as *mut _ as *mut c_void);
+        self.set_run_binding_context_free(Some(Self::free_callback::<Func>));
+
+        self.set_desc_run(Some(Self::execute_run::<Func> as unsafe extern "C" fn(_)));
+        //TODO are we sure this shouldn't be instanced?
+        self.build()
+    }
+
+    /// run iter iterator. loops the iterator automatically compared to `run()`
+    ///
+    /// The "iter" iterator accepts a function that is invoked for each matching
+    /// table. The following function signature is valid:
+    ///  - func(it: &mut Iter, comp1 : &mut T1, comp2 : &mut T2, ...)
+    ///
+    /// Iter iterators are not automatically instanced. When a result contains
+    /// shared components, entities of the result will be iterated one by one.
+    /// This ensures that applications can't accidentally read out of bounds by
+    /// accessing a shared component as an array.
+    ///
+    /// # Example
+    /// ```
+    /// use std::{rc::Rc, cell::RefCell};
+    /// use flecs_ecs::prelude::*;
+    ///
+    /// #[derive(Component, Debug)]
+    /// struct Tag;
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Position {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Velocity {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// let world = World::new();
+    ///
+    /// world
+    ///     .entity()
+    ///     .add::<Tag>()
+    ///     .add::<Position>()
+    ///     .set(Velocity { x: 3, y: 4 });
+    ///
+    /// world
+    ///     .entity()
+    ///     .add::<Tag>()
+    ///     .add::<Position>()
+    ///     .set(Velocity { x: 1, y: 2 });
+    ///
+    /// world
+    ///     .entity()
+    ///     .add::<Position>()
+    ///     .set(Velocity { x: 3, y: 4 });
+    ///
+    /// let count_entities = Rc::new(RefCell::new(0));
+    /// let count_tables = Rc::new(RefCell::new(0));
+    /// let count_entities_ref = count_entities.clone();
+    /// let count_tables_ref = count_tables.clone();
+    ///
+    /// let system = world
+    ///     .system::<(&mut Position, &Velocity)>()
+    ///     .run_iter(move |it, (pos, vel)| {
+    ///         *count_tables_ref.borrow_mut() += 1;
+    ///         for i in it.iter() {
+    ///             *count_entities_ref.borrow_mut() += 1;
+    ///             let entity = it.entity(i);
+    ///             pos[i].x += vel[i].x;
+    ///             pos[i].y += vel[i].y;
+    ///             println!("{:?}: {:?}", entity, pos[i]);
+    ///         }
+    ///     });
+    /// system.run();
+    ///
+    /// assert_eq!(*count_tables.borrow(), 2);
+    /// assert_eq!(*count_entities.borrow(), 3);
+    ///
+    /// // Output:
+    /// // Entity name:  -- id: 508 -- archetype: flecs_ecs.Tag, flecs_ecs.Position, flecs_ecs.Velocity: Position { x: 3, y: 4 }
+    /// // Entity name:  -- id: 510 -- archetype: flecs_ecs.Tag, flecs_ecs.Position, flecs_ecs.Velocity: Position { x: 1, y: 2 }
+    /// // Entity name:  -- id: 511 -- archetype: flecs_ecs.Position, flecs_ecs.Velocity: Position { x: 3, y: 4 }
+    /// ```
+    fn run_iter<Func>(&mut self, func: Func) -> <Self as builder::Builder<'a>>::BuiltType
+    where
+        Func: FnMut(Iter<false, P>, T::TupleSliceType<'_>) + 'static,
+    {
         let iter_func = Box::new(func);
         let iter_static_ref = Box::leak(iter_func);
-        binding_ctx.iter_only = Some(iter_static_ref as *mut _ as *mut c_void);
-        binding_ctx.free_iter_only = Some(Self::on_free_iter_only);
 
-        self.set_desc_callback(Some(Self::run_iter_only::<Func> as unsafe extern "C" fn(_)));
-
+        self.set_callback_binding_context(iter_static_ref as *mut _ as *mut c_void);
+        self.set_callback_binding_context_free(Some(Self::free_callback::<Func>));
+        self.set_desc_callback(Some(
+            Self::execute_run_iter::<Func> as unsafe extern "C" fn(_),
+        ));
         //TODO are we sure this shouldn't be instanced?
+        self.build()
+    }
+
+    /// Run iterator with each forwarding. This operation expects manual
+    /// iteration over the tables with `iter.next_iter()` and `iter.each()`
+    ///
+    /// The "iter" iterator accepts a function that is invoked for each matching
+    /// table. The following function signature is valid:
+    ///  - func: (it: &mut Iter) + func_each: (comp1 : &mut T1, comp2 : &mut T2, ...)
+    ///
+    /// allows for more control over how entities
+    /// are iterated as it provides multiple entities in the same callback
+    /// and allows to determine what should happen before and past iteration.
+    ///
+    /// Iter iterators are not automatically instanced. When a result contains
+    /// shared components, entities of the result will be iterated one by one.
+    /// This ensures that applications can't accidentally read out of bounds by
+    /// accessing a shared component as an array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::{rc::Rc, cell::RefCell};
+    /// use flecs_ecs::prelude::*;
+    ///
+    /// #[derive(Component, Debug)]
+    /// struct Tag;
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Position {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Velocity {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// let world = World::new();
+    ///
+    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add::<Tag>().add::<Position>();
+    /// world
+    ///     .entity()
+    ///     .add::<Tag>()
+    ///     .add::<Position>()
+    ///     .add::<Velocity>();
+    ///
+    ///
+    ///
+    /// let count_entities = Rc::new(RefCell::new(0));
+    /// let count_tables = Rc::new(RefCell::new(0));
+    /// // Clone the `Rc` to retain shared ownership and move it into the closure to satisfy the 'static lifetime requirement.
+    /// let count_entities_ref = count_entities.clone();
+    /// let count_tables_ref = count_tables.clone();
+    ///
+    /// let system = world.system::<(&Tag, &Position)>().run_each(
+    ///     move |mut it| {
+    ///         println!("start operations");
+    ///         while it.next_iter() {
+    ///             *count_tables_ref.borrow_mut() += 1;
+    ///             it.each();
+    ///         }
+    ///         println!("end operations");
+    ///     },
+    ///     move |(tag, pos)| {
+    ///         *count_entities_ref.borrow_mut() += 1;
+    ///         println!("{:?}, {:?}", tag, pos);
+    ///     },
+    /// );
+    ///
+    /// system.run();
+    ///
+    /// assert_eq!(*count_tables.borrow(), 2);
+    /// assert_eq!(*count_entities.borrow(), 3);
+    ///
+    /// // Output:
+    /// //  start operations
+    /// //  Tag, Position { x: 0, y: 0 }
+    /// //  Tag, Position { x: 0, y: 0 }
+    /// //  Tag, Position { x: 0, y: 0 }
+    /// //  end operations
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `iterable::run`
+    #[doc(alias = "iterable::run")]
+    fn run_each<Func, FuncEach>(
+        &mut self,
+        func: Func,
+        func_each: FuncEach,
+    ) -> <Self as builder::Builder<'a>>::BuiltType
+    where
+        Func: FnMut(Iter<true, P>) + 'static,
+        FuncEach: FnMut(T::TupleType<'_>) + 'static,
+    {
+        let run_func = Box::new(func);
+        let run_static_ref = Box::leak(run_func);
+
+        self.set_run_binding_context(run_static_ref as *mut _ as *mut c_void);
+        self.set_run_binding_context_free(Some(Self::free_callback::<Func>));
+
+        self.set_desc_run(Some(Self::execute_run::<Func> as unsafe extern "C" fn(_)));
+
+        let each_func = Box::new(func_each);
+        let each_static_ref = Box::leak(each_func);
+
+        self.set_callback_binding_context(each_static_ref as *mut _ as *mut c_void);
+        self.set_callback_binding_context_free(Some(Self::free_callback::<FuncEach>));
+
+        self.set_desc_callback(Some(
+            Self::execute_each::<true, FuncEach> as unsafe extern "C" fn(_),
+        ));
 
         self.build()
     }
 
-    fn iter<Func>(&mut self, func: Func) -> <Self as builder::Builder<'a>>::BuiltType
+    /// Run iterator with each entity forwarding. This operation expects manual
+    /// iteration over the tables with `iter.next_iter()` and `iter.each()`  
+    ///
+    /// The "iter" iterator accepts a function that is invoked for each matching
+    /// table. The following function signature is valid:
+    /// - func: (it: &mut Iter) + func_each_entity: (entity: EntityView, comp1 : &mut T1, comp2 : &mut T2, ...)
+    ///
+    /// allows for more control over how entities
+    /// are iterated as it provides multiple entities in the same callback
+    /// and allows to determine what should happen before and past iteration.
+    ///
+    /// Iter iterators are not automatically instanced. When a result contains
+    /// shared components, entities of the result will be iterated one by one.
+    /// This ensures that applications can't accidentally read out of bounds by
+    /// accessing a shared component as an array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::{rc::Rc, cell::RefCell};
+    /// use flecs_ecs::prelude::*;
+    ///
+    /// #[derive(Component, Debug)]
+    /// struct Tag;
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Position {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// #[derive(Debug, Component, Default)]
+    /// pub struct Velocity {
+    ///     pub x: i32,
+    ///     pub y: i32,
+    /// }
+    ///
+    /// let world = World::new();
+    ///
+    /// world.entity().add::<Tag>().add::<Position>();
+    /// world.entity().add::<Tag>().add::<Position>();
+    /// world
+    ///     .entity()
+    ///     .add::<Tag>()
+    ///     .add::<Position>()
+    ///     .add::<Velocity>();
+    ///
+    ///
+    ///
+    /// let count_entities = Rc::new(RefCell::new(0));
+    /// let count_tables = Rc::new(RefCell::new(0));
+    /// // Clone the `Rc` to retain shared ownership and move it into the closure to satisfy the 'static lifetime requirement.
+    /// let count_entities_ref = count_entities.clone();
+    /// let count_tables_ref = count_tables.clone();
+    ///
+    /// let system = world.system::<(&Tag, &Position)>().run_each_entity(
+    ///     move |mut it| {
+    ///         println!("start operations");
+    ///         while it.next_iter() {
+    ///             *count_tables_ref.borrow_mut() += 1;
+    ///             it.each();
+    ///         }
+    ///         println!("end operations");
+    ///     },
+    ///     move |e, (tag, pos)| {
+    ///         *count_entities_ref.borrow_mut() += 1;
+    ///         println!("{:?}: {:?}, {:?}", e, tag, pos);
+    ///     },
+    /// );
+    ///
+    /// system.run();
+    ///
+    /// assert_eq!(*count_tables.borrow(), 2);
+    /// assert_eq!(*count_entities.borrow(), 3);
+    ///
+    /// // Output:
+    /// //  start operations
+    /// //  Entity name:  -- id: 508 -- archetype: flecs_ecs.main.Tag, flecs_ecs.main.Position: Position { x: 0, y: 0 }
+    /// //  Entity name:  -- id: 511 -- archetype: flecs_ecs.main.Tag, flecs_ecs.main.Position: Position { x: 0, y: 0 }
+    /// //  Entity name:  -- id: 512 -- archetype: flecs_ecs.main.Tag, flecs_ecs.main.Position, flecs_ecs.main.Velocity: Position { x: 0, y: 0 }
+    /// //  end operations
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `iterable::run`
+    #[doc(alias = "iterable::run")]
+    fn run_each_entity<Func, FuncEachEntity>(
+        &mut self,
+        func: Func,
+        func_each_entity: FuncEachEntity,
+    ) -> <Self as builder::Builder<'a>>::BuiltType
     where
-        Func: FnMut(Iter<P>, T::TupleSliceType<'_>) + 'static,
+        Func: FnMut(Iter<true, P>) + 'static,
+        FuncEachEntity: FnMut(EntityView, T::TupleType<'_>) + 'static,
     {
-        let binding_ctx = self.get_binding_context();
+        let run_func = Box::new(func);
+        let run_static_ref = Box::leak(run_func);
 
-        let iter_func = Box::new(func);
-        let iter_static_ref = Box::leak(iter_func);
+        self.set_run_binding_context(run_static_ref as *mut _ as *mut c_void);
+        self.set_run_binding_context_free(Some(Self::free_callback::<Func>));
 
-        binding_ctx.iter = Some(iter_static_ref as *mut _ as *mut c_void);
-        binding_ctx.free_iter = Some(Self::on_free_iter);
+        self.set_desc_run(Some(Self::execute_run::<Func> as unsafe extern "C" fn(_)));
 
-        self.set_desc_callback(Some(Self::run_iter::<Func> as unsafe extern "C" fn(_)));
+        let each_entity_func = Box::new(func_each_entity);
+        let each_entity_static_ref = Box::leak(each_entity_func);
 
-        //TODO are we sure this shouldn't be instanced?
+        self.set_callback_binding_context(each_entity_static_ref as *mut _ as *mut c_void);
+        self.set_callback_binding_context_free(Some(Self::free_callback::<FuncEachEntity>));
+
+        self.set_desc_callback(Some(
+            Self::execute_each_entity::<true, FuncEachEntity> as unsafe extern "C" fn(_),
+        ));
 
         self.build()
     }
@@ -134,16 +506,29 @@ macro_rules! implement_reactor_api {
         where
             T: Iterable,
         {
-            fn set_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
+            fn set_callback_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
                 self.desc.callback_ctx = binding_ctx;
                 self
             }
 
-            fn set_binding_context_free(
+            fn set_callback_binding_context_free(
                 &mut self,
                 binding_ctx_free: flecs_ecs_sys::ecs_ctx_free_t,
             ) -> &mut Self {
                 self.desc.callback_ctx_free = binding_ctx_free;
+                self
+            }
+
+            fn set_run_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
+                self.desc.run_ctx = binding_ctx;
+                self
+            }
+
+            fn set_run_binding_context_free(
+                &mut self,
+                run_ctx_free: flecs_ecs_sys::ecs_ctx_free_t,
+            ) -> &mut Self {
+                self.desc.run_ctx_free = run_ctx_free;
                 self
             }
 
@@ -157,20 +542,19 @@ macro_rules! implement_reactor_api {
             ) {
                 self.desc.callback = callback;
             }
+
+            fn set_desc_run(
+                &mut self,
+                callback: Option<unsafe extern "C" fn(*mut sys::ecs_iter_t)>,
+            ) {
+                self.desc.run = callback;
+            }
         }
 
         impl<'a, T> ReactorAPI<'a, $param, T> for $type
         where
             T: Iterable,
         {
-            fn set_run_callback(
-                &mut self,
-                callback: flecs_ecs::sys::ecs_iter_action_t,
-            ) -> &mut Self {
-                self.desc.run = callback;
-                self
-            }
-
             // fn set_instanced(&mut self, instanced: bool) {
             //     self.is_instanced = instanced;
             // }
@@ -187,16 +571,29 @@ macro_rules! implement_reactor_api {
             T: Iterable,
             P: ComponentId,
         {
-            fn set_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
+            fn set_callback_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
                 self.desc.callback_ctx = binding_ctx;
                 self
             }
 
-            fn set_binding_context_free(
+            fn set_callback_binding_context_free(
                 &mut self,
                 binding_ctx_free: flecs_ecs_sys::ecs_ctx_free_t,
             ) -> &mut Self {
                 self.desc.callback_ctx_free = binding_ctx_free;
+                self
+            }
+
+            fn set_run_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
+                self.desc.run_ctx = binding_ctx;
+                self
+            }
+
+            fn set_run_binding_context_free(
+                &mut self,
+                run_ctx_free: flecs_ecs_sys::ecs_ctx_free_t,
+            ) -> &mut Self {
+                self.desc.run_ctx_free = run_ctx_free;
                 self
             }
 
@@ -210,6 +607,13 @@ macro_rules! implement_reactor_api {
             ) {
                 self.desc.callback = callback;
             }
+
+            fn set_desc_run(
+                &mut self,
+                callback: Option<unsafe extern "C" fn(*mut sys::ecs_iter_t)>,
+            ) {
+                self.desc.run = callback;
+            }
         }
 
         impl<'a, P, T> ReactorAPI<'a, P, T> for $type
@@ -217,14 +621,6 @@ macro_rules! implement_reactor_api {
             T: Iterable,
             P: ComponentId,
         {
-            fn set_run_callback(
-                &mut self,
-                callback: flecs_ecs::sys::ecs_iter_action_t,
-            ) -> &mut Self {
-                self.desc.run = callback;
-                self
-            }
-
             // fn set_instanced(&mut self, instanced: bool) {
             //     self.is_instanced = instanced;
             // }
@@ -237,5 +633,4 @@ macro_rules! implement_reactor_api {
     };
 }
 
-use flecs_ecs_sys::ecs_iter_action_t;
 pub(crate) use implement_reactor_api;

--- a/flecs_ecs/src/core/utility/traits/reactor.rs
+++ b/flecs_ecs/src/core/utility/traits/reactor.rs
@@ -7,8 +7,6 @@ where
     T: Iterable,
     P: ComponentId,
 {
-    //fn set_instanced(&mut self, instanced: bool);
-
     /// Set context
     ///
     /// # See also
@@ -32,7 +30,7 @@ where
             Self::execute_each::<false, Func> as unsafe extern "C" fn(_),
         ));
 
-        //self.set_instanced(true);
+        self.set_instanced(true);
 
         self.build()
     }
@@ -50,7 +48,7 @@ where
             Self::execute_each_entity::<false, Func> as unsafe extern "C" fn(_),
         ));
 
-        //self.set_instanced(true);
+        self.set_instanced(true);
 
         self.build()
     }
@@ -65,11 +63,13 @@ where
         self.set_callback_binding_context(each_iter_static_ref as *mut _ as *mut c_void);
         self.set_callback_binding_context_free(Some(Self::free_callback::<Func>));
 
+        self.set_instanced(true);
+
         self.set_desc_callback(Some(
             Self::execute_each_iter::<Func> as unsafe extern "C" fn(_),
         ));
 
-        //self.set_instanced(true);
+        self.set_instanced(true);
 
         self.build()
     }
@@ -375,6 +375,8 @@ where
         self.set_callback_binding_context(each_static_ref as *mut _ as *mut c_void);
         self.set_callback_binding_context_free(Some(Self::free_callback::<FuncEach>));
 
+        self.set_instanced(true);
+
         self.set_desc_callback(Some(
             Self::execute_each::<true, FuncEach> as unsafe extern "C" fn(_),
         ));
@@ -492,6 +494,8 @@ where
         self.set_callback_binding_context(each_entity_static_ref as *mut _ as *mut c_void);
         self.set_callback_binding_context_free(Some(Self::free_callback::<FuncEachEntity>));
 
+        self.set_instanced(true);
+
         self.set_desc_callback(Some(
             Self::execute_each_entity::<true, FuncEachEntity> as unsafe extern "C" fn(_),
         ));
@@ -506,6 +510,10 @@ macro_rules! implement_reactor_api {
         where
             T: Iterable,
         {
+            fn set_instanced(&mut self, instanced: bool) {
+                self.is_instanced = instanced;
+            }
+
             fn set_callback_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
                 self.desc.callback_ctx = binding_ctx;
                 self
@@ -555,10 +563,6 @@ macro_rules! implement_reactor_api {
         where
             T: Iterable,
         {
-            // fn set_instanced(&mut self, instanced: bool) {
-            //     self.is_instanced = instanced;
-            // }
-
             fn set_context(&mut self, context: *mut c_void) -> &mut Self {
                 self.desc.ctx = context;
                 self
@@ -571,6 +575,10 @@ macro_rules! implement_reactor_api {
             T: Iterable,
             P: ComponentId,
         {
+            fn set_instanced(&mut self, instanced: bool) {
+                self.is_instanced = instanced;
+            }
+
             fn set_callback_binding_context(&mut self, binding_ctx: *mut c_void) -> &mut Self {
                 self.desc.callback_ctx = binding_ctx;
                 self
@@ -621,10 +629,6 @@ macro_rules! implement_reactor_api {
             T: Iterable,
             P: ComponentId,
         {
-            // fn set_instanced(&mut self, instanced: bool) {
-            //     self.is_instanced = instanced;
-            // }
-
             fn set_context(&mut self, context: *mut c_void) -> &mut Self {
                 self.desc.ctx = context;
                 self

--- a/flecs_ecs/src/core/utility/types.rs
+++ b/flecs_ecs/src/core/utility/types.rs
@@ -4,90 +4,48 @@ pub type FTime = f32;
 
 pub(crate) type EcsCtxFreeT = extern "C" fn(*mut c_void);
 
-#[doc(hidden)]
-pub struct ObserverSystemBindingCtx {
-    pub(crate) each: Option<*mut c_void>,
-    pub(crate) each_entity: Option<*mut c_void>,
-    pub(crate) each_iter: Option<*mut c_void>,
-    pub(crate) iter: Option<*mut c_void>,
-    pub(crate) iter_only: Option<*mut c_void>,
-    pub(crate) free_each: Option<EcsCtxFreeT>,
-    pub(crate) free_each_entity: Option<EcsCtxFreeT>,
-    pub(crate) free_each_iter: Option<EcsCtxFreeT>,
-    pub(crate) free_iter: Option<EcsCtxFreeT>,
-    pub(crate) free_iter_only: Option<EcsCtxFreeT>,
-}
+// #[doc(hidden)]
+// pub struct ReactorBindingType {
+//     pub(crate) callback: Option<*mut c_void>,
+//     pub(crate) free_callback: Option<EcsCtxFreeT>,
+// }
 
-impl Drop for ObserverSystemBindingCtx {
-    fn drop(&mut self) {
-        if let Some(each) = self.each {
-            if let Some(free_each) = self.free_each {
-                free_each(each);
-            }
-        }
-        if let Some(each_entity) = self.each_entity {
-            if let Some(free_each_entity) = self.free_each_entity {
-                free_each_entity(each_entity);
-            }
-        }
-        if let Some(iter) = self.iter {
-            if let Some(free_iter) = self.free_iter {
-                free_iter(iter);
-            }
-        }
-        if let Some(iter_only) = self.iter_only {
-            if let Some(free_iter_only) = self.free_iter_only {
-                free_iter_only(iter_only);
-            }
-        }
-    }
-}
+// impl Drop for ReactorBindingType {
+//     fn drop(&mut self) {
+//         if let Some(callback) = self.callback {
+//             if let Some(free_callback) = self.free_callback {
+//                 free_callback(callback);
+//             }
+//         }
+//     }
+// }
 
-#[allow(clippy::derivable_impls)]
-impl Default for ObserverSystemBindingCtx {
-    fn default() -> Self {
-        Self {
-            each: None,
-            each_entity: None,
-            each_iter: None,
-            iter: None,
-            iter_only: None,
-            free_each: None,
-            free_each_entity: None,
-            free_each_iter: None,
-            free_iter: None,
-            free_iter_only: None,
-        }
-    }
-}
-impl ObserverSystemBindingCtx {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        each: Option<*mut c_void>,
-        each_entity: Option<*mut c_void>,
-        each_iter: Option<*mut c_void>,
-        iter: Option<*mut c_void>,
-        iter_only: Option<*mut c_void>,
-        free_each: Option<EcsCtxFreeT>,
-        free_each_entity: Option<EcsCtxFreeT>,
-        free_each_iter: Option<EcsCtxFreeT>,
-        free_iter: Option<EcsCtxFreeT>,
-        free_iter_only: Option<EcsCtxFreeT>,
-    ) -> Self {
-        Self {
-            each,
-            each_entity,
-            each_iter,
-            iter,
-            iter_only,
-            free_each,
-            free_each_entity,
-            free_each_iter,
-            free_iter,
-            free_iter_only,
-        }
-    }
-}
+// impl Default for ReactorBindingType {
+//     fn default() -> Self {
+//         Self {
+//             callback: None,
+//             free_callback: None,
+//         }
+//     }
+// }
+
+// impl ReactorBindingType {
+//     pub(crate) fn new(callback: Option<*mut c_void>, free_callback: Option<EcsCtxFreeT>) -> Self {
+//         Self {
+//             callback,
+//             free_callback,
+//         }
+//     }
+// }
+// pub(crate) enum TypeBinding {
+//     Each(ReactorBindingType),
+//     EachEntity(ReactorBindingType),
+//     EachIter(ReactorBindingType),
+//     Run(ReactorBindingType),
+//     RunIter(ReactorBindingType),
+//     RunEach(ReactorBindingType),
+//     RunEachEntity(ReactorBindingType),
+// }
 
 pub(crate) struct ObserverEntityBindingCtx {
     pub(crate) empty: Option<*mut c_void>,

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -1415,6 +1415,7 @@ impl World {
     pub fn get_ref<T>(&self) -> CachedRef<T::UnderlyingType>
     where
         T: ComponentId + NotEmptyComponent,
+        T::UnderlyingType: NotEmptyComponent,
     {
         EntityView::new_from(self, T::get_id(self)).get_ref::<T>()
     }

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -940,12 +940,12 @@ impl World {
     ///
     /// * C++ API: `world::set`
     #[doc(alias = "world::set")]
-    pub unsafe fn set_first<First>(&self, second: impl Into<Entity>, first: First)
+    pub fn set_first<First>(&self, second: impl Into<Entity>, first: First)
     where
         First: ComponentId + ComponentType<Struct> + NotEmptyComponent,
     {
         let entity = EntityView::new_from(self, First::get_id(self));
-        entity.set_first::<First>(first, second);
+        entity.set_first::<First>(second, first);
     }
 
     /// Set a singleton pair using the second element type and a first id.
@@ -958,12 +958,12 @@ impl World {
     ///
     /// * C++ API: `world::set`
     #[doc(alias = "world::set")]
-    pub unsafe fn set_second<Second>(&self, first: impl Into<Entity>, second: Second)
+    pub fn set_second<Second>(&self, first: impl Into<Entity>, second: Second)
     where
         Second: ComponentId + ComponentType<Struct> + NotEmptyComponent,
     {
         let entity = EntityView::new_from(self, Second::get_id(self));
-        entity.set_second::<Second>(second, first);
+        entity.set_second::<Second>(first, second);
     }
 
     /// Set singleton pair.
@@ -980,13 +980,9 @@ impl World {
         Second: ComponentId,
         (First, Second): FlecsCastType,
     {
-        // const {
-        //     assert!(!<(First, Second) as IntoComponentId>::IS_TAGS, "setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
-        // };
-        // TODO: rust 1.79 const compiler error
-        if <(First, Second) as IntoComponentId>::IS_TAGS {
-            panic!("setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
-        }
+        const {
+            assert!(!<(First, Second) as IntoComponentId>::IS_TAGS, "setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
+        };
 
         let entity = EntityView::new_from(
             self,
@@ -1699,9 +1695,9 @@ impl World {
     /// * C++ API: `world::add`
     #[doc(alias = "world::add")]
     #[inline(always)]
-    pub fn add_enum_tag<First, Second>(&self, enum_value: Second) -> EntityView
+    pub fn add_pair_enum<First, Second>(&self, enum_value: Second) -> EntityView
     where
-        First: ComponentId + EmptyComponent,
+        First: ComponentId,
         Second: ComponentId + ComponentType<Enum> + CachedEnumData,
     {
         EntityView::new_from(self, First::get_id(self)).add_pair_enum::<First, Second>(enum_value)

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -982,9 +982,9 @@ impl World {
         Second: ComponentId,
         (First, Second): FlecsCastType,
     {
-        const {
-            assert!(!<(First, Second) as IntoComponentId>::IS_TAGS, "setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
-        };
+        // const {
+        //     assert!(!<(First, Second) as IntoComponentId>::IS_TAGS, "setting tag relationships is not possible with `set_pair`. use `add_pair` instead.");
+        // };
 
         let entity = EntityView::new_from(
             self,

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -20,6 +20,8 @@ pub struct World {
     pub(crate) raw_world: NonNull<WorldT>,
 }
 
+unsafe impl Send for World {}
+
 impl Clone for World {
     fn clone(&self) -> Self {
         unsafe { sys::flecs_poly_claim_(self.raw_world.as_ptr() as *mut c_void) };

--- a/flecs_ecs/src/core/world_ctx.rs
+++ b/flecs_ecs/src/core/world_ctx.rs
@@ -71,7 +71,7 @@ fn query_ref_count() {
     struct Tag;
 
     let world = World::new();
-    let query = world.query::<&Tag>().build();
+    let query = world.query::<()>().with::<&Tag>().build();
 
     assert_eq!(world.world_ctx().query_ref_count(), 1);
     assert_eq!(query.reference_count(), 1);

--- a/flecs_ecs/tests/flecs/entity_test.rs
+++ b/flecs_ecs/tests/flecs/entity_test.rs
@@ -1065,7 +1065,7 @@ fn entity_is_first_enabled() {
 
     let e = world
         .entity()
-        .set_first::<Position>(Position { x: 0, y: 0 }, tgt_a);
+        .set_first::<Position>(tgt_a, Position { x: 0, y: 0 });
 
     assert!(e.is_enabled_first::<Position>(tgt_a));
     assert!(!e.is_enabled_first::<Position>(tgt_b));
@@ -1229,7 +1229,7 @@ fn entity_override_pair_w_tgt_id() {
     let base = world
         .entity()
         .auto_override_first::<Position>(tgt_a)
-        .set_first::<Position>(Position { x: 0, y: 0 }, tgt_b);
+        .set_first::<Position>(tgt_b, Position { x: 0, y: 0 });
 
     let entity = world.entity().add_id((flecs::IsA::ID, base));
 

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -949,7 +949,7 @@ fn query_builder_singleton_term() {
 
     let mut count = 0;
 
-    q.iter(|it, s| {
+    q.run_iter(|it, s| {
         let o = &it.field::<Other>(1).unwrap()[0];
         assert!(!it.is_self(1));
         assert_eq!(o.value, 10);
@@ -992,7 +992,7 @@ fn query_builder_isa_superset_term() {
 
     let mut count = 0;
 
-    q.iter(|it, s| {
+    q.run_iter(|it, s| {
         let o = &it.field::<Other>(1).unwrap()[0];
         assert!(!it.is_self(1));
         assert_eq!(o.value, 10);
@@ -1041,7 +1041,7 @@ fn query_builder_isa_self_superset_term() {
     let mut count = 0;
     let mut owned_count = 0;
 
-    q.iter(|it, s| {
+    q.run_iter(|it, s| {
         let o = &it.field::<Other>(1).unwrap();
 
         if !it.is_self(1) {
@@ -1088,7 +1088,7 @@ fn query_builder_childof_superset_term() {
 
     let mut count = 0;
 
-    q.iter(|it, s| {
+    q.run_iter(|it, s| {
         let o = &it.field::<Other>(1).unwrap()[0];
         assert!(!it.is_self(1));
         assert_eq!(o.value, 10);
@@ -1133,7 +1133,7 @@ fn query_builder_childof_self_superset_term() {
     let mut count = 0;
     let mut owned_count = 0;
 
-    q.iter(|it, s| {
+    q.run_iter(|it, s| {
         let o = &it.field::<Other>(1).unwrap();
 
         if !it.is_self(1) {
@@ -1878,12 +1878,16 @@ fn query_builder_2_subsequent_args() {
     let world = create_world_with_flags::<Flags>();
 
     let s = world
-        .system::<(&RelFoo, &Velocity)>()
+        .system::<(&mut RelFoo, &Velocity)>()
         .term_at(0)
         .set_second_id(*flecs::Wildcard)
         .term_at(1)
         .singleton()
-        .iter_only(move |it| it.real_world().get::<&mut Flags>(|f| f.count += it.count()));
+        .run(|mut it| {
+            while it.next_iter() {
+                it.real_world().get::<&mut Flags>(|f| f.count += it.count());
+            }
+        });
 
     world.entity().set_pair::<RelFoo, Tag>(RelFoo { foo: 10 });
     world.set(Velocity { x: 0, y: 0 });
@@ -1911,18 +1915,20 @@ fn query_builder_optional_tag_is_set() {
 
     let mut count = 0;
 
-    q.iter_only(|it| {
-        assert_eq!(it.count(), 1);
+    q.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
 
-        count += it.count();
+            count += it.count();
 
-        if it.entity(0) == e_1 {
-            assert!(it.is_set(0));
-            assert!(it.is_set(1));
-        } else {
-            assert_eq!(it.entity(0), e_2);
-            assert!(it.is_set(0));
-            assert!(!it.is_set(1));
+            if it.entity(0) == e_1 {
+                assert!(it.is_set(0));
+                assert!(it.is_set(1));
+            } else {
+                assert_eq!(it.entity(0), e_2);
+                assert!(it.is_set(0));
+                assert!(!it.is_set(1));
+            }
         }
     });
 
@@ -1965,11 +1971,13 @@ fn query_builder_10_terms() {
         .add::<TagJ>();
 
     let mut count = 0;
-    f.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        assert_eq!(it.entity(0), e);
-        assert_eq!(it.field_count(), 10);
-        count += 1;
+    f.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            assert_eq!(it.entity(0), e);
+            assert_eq!(it.field_count(), 10);
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);
@@ -2027,11 +2035,13 @@ fn query_builder_16_terms() {
         .add::<TagT>();
 
     let mut count = 0;
-    f.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        assert_eq!(it.entity(0), e);
-        assert_eq!(it.field_count(), 16);
-        count += 1;
+    f.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            assert_eq!(it.entity(0), e);
+            assert_eq!(it.field_count(), 16);
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);
@@ -2084,34 +2094,38 @@ fn query_builder_group_by_raw() {
 
     let mut count = 0;
 
-    q.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        if count == 0 {
-            assert!(it.entity(0) == e1);
-        } else if count == 1 {
-            assert!(it.entity(0) == e2);
-        } else if count == 2 {
-            assert!(it.entity(0) == e3);
-        } else {
-            panic!();
+    q.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            if count == 0 {
+                assert!(it.entity(0) == e1);
+            } else if count == 1 {
+                assert!(it.entity(0) == e2);
+            } else if count == 2 {
+                assert!(it.entity(0) == e3);
+            } else {
+                panic!();
+            }
+            count += 1;
         }
-        count += 1;
     });
     assert_eq!(count, 3);
 
     count = 0;
-    q_reverse.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        if count == 0 {
-            assert!(it.entity(0) == e3);
-        } else if count == 1 {
-            assert!(it.entity(0) == e2);
-        } else if count == 2 {
-            assert!(it.entity(0) == e1);
-        } else {
-            panic!();
+    q_reverse.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            if count == 0 {
+                assert!(it.entity(0) == e3);
+            } else if count == 1 {
+                assert!(it.entity(0) == e2);
+            } else if count == 2 {
+                assert!(it.entity(0) == e1);
+            } else {
+                panic!();
+            }
+            count += 1;
         }
-        count += 1;
     });
     assert_eq!(count, 3);
 }
@@ -2144,34 +2158,38 @@ fn query_builder_group_by_template() {
 
     let mut count = 0;
 
-    q.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        if count == 0 {
-            assert!(it.entity(0) == e1);
-        } else if count == 1 {
-            assert!(it.entity(0) == e2);
-        } else if count == 2 {
-            assert!(it.entity(0) == e3);
-        } else {
-            panic!();
+    q.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            if count == 0 {
+                assert!(it.entity(0) == e1);
+            } else if count == 1 {
+                assert!(it.entity(0) == e2);
+            } else if count == 2 {
+                assert!(it.entity(0) == e3);
+            } else {
+                panic!();
+            }
+            count += 1;
         }
-        count += 1;
     });
     assert_eq!(count, 3);
 
     count = 0;
-    q_reverse.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        if count == 0 {
-            assert!(it.entity(0) == e3);
-        } else if count == 1 {
-            assert!(it.entity(0) == e2);
-        } else if count == 2 {
-            assert!(it.entity(0) == e1);
-        } else {
-            panic!();
+    q_reverse.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            if count == 0 {
+                assert!(it.entity(0) == e3);
+            } else if count == 1 {
+                assert!(it.entity(0) == e2);
+            } else if count == 2 {
+                assert!(it.entity(0) == e1);
+            } else {
+                panic!();
+            }
+            count += 1;
         }
-        count += 1;
     });
     assert_eq!(count, 3);
 }
@@ -2312,7 +2330,7 @@ fn query_builder_group_by_iter_one_all_groups() {
     let e5_found = Cell::new(false);
     let e6_found = Cell::new(false);
 
-    let func = |it: Iter, size: usize, ()| {
+    let func = |it: Iter<false>, size: usize, ()| {
         let e = it.entity(size);
         if it.group_id() == group_id.get() {
             if e == e1 {
@@ -2381,7 +2399,7 @@ fn query_builder_group_by_default_func_w_id() {
     let mut e3_found = false;
     let mut count = 0;
 
-    q.each_iter(|it: Iter, size: usize, ()| {
+    q.each_iter(|it: Iter<false>, size: usize, ()| {
         let e = it.entity(size);
         if e == e1 {
             assert_eq!(it.group_id(), tgt_c);
@@ -2437,7 +2455,7 @@ fn query_builder_group_by_default_func_w_type() {
     let mut e3_found = false;
     let mut count = 0;
 
-    q.each_iter(|it: Iter, size: usize, ()| {
+    q.each_iter(|it: Iter<false>, size: usize, ()| {
         let e = it.entity(size);
         if e == e1 {
             assert_eq!(it.group_id(), tgt_c);
@@ -2528,7 +2546,7 @@ fn query_builder_group_by_callbacks() {
     let mut e3_found = false;
     let mut count = 0;
 
-    q.each_iter(|it: Iter, size: usize, ()| {
+    q.each_iter(|it: Iter<false>, size: usize, ()| {
         let e = it.entity(size);
         if e == e1 {
             assert_eq!(it.group_id(), tgt_c);
@@ -2822,7 +2840,7 @@ fn query_builder_up_w_type() {
 
     let mut count = 0;
 
-    q.iter(|it, s| {
+    q.run_iter(|it, s| {
         let o = &it.field::<Other2>(1).unwrap()[0];
         assert!(!it.is_self(1));
         assert_eq!(o.value, 10);
@@ -3301,7 +3319,7 @@ fn query_builder_name_arg() {
         .build();
 
     let mut count = 0;
-    f.iter(|it, p| {
+    f.run_iter(|it, p| {
         count += 1;
         assert_eq!(p[0].x, 10);
         assert_eq!(p[0].y, 20);
@@ -3325,13 +3343,15 @@ fn query_builder_const_in_term() {
         .build();
 
     let mut count = 0;
-    f.iter_only(|it| {
-        let p = it.field::<Position>(0).unwrap();
-        assert!(it.is_readonly(0));
-        for i in it.iter() {
-            count += 1;
-            assert_eq!(p[i].x, 10);
-            assert_eq!(p[i].y, 20);
+    f.run(|mut it| {
+        while it.next_iter() {
+            let p = it.field::<Position>(0).unwrap();
+            assert!(it.is_readonly(0));
+            for i in it.iter() {
+                count += 1;
+                assert_eq!(p[i].x, 10);
+                assert_eq!(p[i].y, 20);
+            }
         }
     });
 
@@ -3353,16 +3373,18 @@ fn query_builder_const_optional() {
 
     let mut count = 0;
     let mut set_count = 0;
-    f.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        if it.is_set(1) {
-            let p = &it.field::<Position2>(1).unwrap()[0];
-            assert!(it.is_readonly(1));
-            assert_eq!(p.x, 10);
-            assert_eq!(p.y, 20);
-            set_count += 1;
+    f.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            if it.is_set(1) {
+                let p = &it.field::<Position2>(1).unwrap()[0];
+                assert!(it.is_readonly(1));
+                assert_eq!(p.x, 10);
+                assert_eq!(p.y, 20);
+                set_count += 1;
+            }
+            count += 1;
         }
-        count += 1;
     });
 
     assert_eq!(count, 2);
@@ -3538,13 +3560,15 @@ fn query_builder_iter_column_w_const_as_array() {
     let e2 = world.entity().set(Position { x: 20, y: 30 });
 
     let mut count = 0;
-    f.iter_only(|it| {
-        let mut p = it.field::<Position>(0).unwrap();
-        for i in it.iter() {
-            p[i].x += 1;
-            p[i].y += 2;
+    f.run(|mut it| {
+        while it.next_iter() {
+            let mut p = it.field::<Position>(0).unwrap();
+            for i in it.iter() {
+                p[i].x += 1;
+                p[i].y += 2;
 
-            count += 1;
+                count += 1;
+            }
         }
     });
 
@@ -3576,12 +3600,14 @@ fn query_builder_iter_column_w_const_as_ptr() {
     world.entity().is_a_id(base);
 
     let mut count = 0;
-    f.iter_only(|it| {
-        let p = &it.field::<Position>(0).unwrap()[0];
-        for _i in it.iter() {
-            assert_eq!(p.x, 10);
-            assert_eq!(p.y, 20);
-            count += 1;
+    f.run(|mut it| {
+        while it.next_iter() {
+            let p = &it.field::<Position>(0).unwrap()[0];
+            for _i in it.iter() {
+                assert_eq!(p.x, 10);
+                assert_eq!(p.y, 20);
+                count += 1;
+            }
         }
     });
 
@@ -4840,9 +4866,11 @@ fn query_builder_var_src_w_prefixed_name() {
     let e = world.entity().add::<Foo>();
 
     let mut count = 0;
-    r.iter_only(|it| {
-        assert_eq!(it.get_var_by_name("Var"), e);
-        count += 1;
+    r.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.get_var_by_name("Var"), e);
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);
@@ -4864,11 +4892,13 @@ fn query_builder_var_first_w_prefixed_name() {
     let e = world.entity().add::<Foo>();
 
     let mut count = 0;
-    r.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        assert_eq!(it.entity(0), e);
-        assert_eq!(it.get_var_by_name("Var"), world.id_from::<Foo>());
-        count += 1;
+    r.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            assert_eq!(it.entity(0), e);
+            assert_eq!(it.get_var_by_name("Var"), world.id_from::<Foo>());
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);
@@ -4890,11 +4920,13 @@ fn query_builder_var_second_w_prefixed_name() {
     let e = world.entity().add_first::<Foo>(t);
 
     let mut count = 0;
-    r.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        assert_eq!(it.entity(0), e);
-        assert_eq!(it.get_var_by_name("Var"), t);
-        count += 1;
+    r.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            assert_eq!(it.entity(0), e);
+            assert_eq!(it.get_var_by_name("Var"), t);
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);
@@ -4917,11 +4949,13 @@ fn query_builder_term_w_second_var_string() {
     let e = world.entity().add_id((foo_, t));
 
     let mut count = 0;
-    r.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        assert_eq!(it.entity(0), e);
-        assert_eq!(it.get_var_by_name("Var"), t);
-        count += 1;
+    r.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            assert_eq!(it.entity(0), e);
+            assert_eq!(it.get_var_by_name("Var"), t);
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);
@@ -4942,11 +4976,13 @@ fn query_builder_term_type_w_second_var_string() {
     let e = world.entity().add_first::<Foo>(t);
 
     let mut count = 0;
-    r.iter_only(|it| {
-        assert_eq!(it.count(), 1);
-        assert_eq!(it.entity(0), e);
-        assert_eq!(it.get_var_by_name("Var"), t);
-        count += 1;
+    r.run(|mut it| {
+        while it.next_iter() {
+            assert_eq!(it.count(), 1);
+            assert_eq!(it.entity(0), e);
+            assert_eq!(it.get_var_by_name("Var"), t);
+            count += 1;
+        }
     });
 
     assert_eq!(count, 1);

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -1878,9 +1878,7 @@ fn query_builder_2_subsequent_args() {
     let world = create_world_with_flags::<Flags>();
 
     let s = world
-        .system::<(&mut RelFoo, &Velocity)>()
-        .term_at(0)
-        .set_second_id(*flecs::Wildcard)
+        .system::<(&mut (RelFoo, flecs::Wildcard), &Velocity)>()
         .term_at(1)
         .singleton()
         .run(|mut it| {

--- a/flecs_ecs/tests/flecs/query_test.rs
+++ b/flecs_ecs/tests/flecs/query_test.rs
@@ -11,7 +11,11 @@ fn query_uncached_destruction_no_panic() {
     let query = world.new_query::<&Tag>();
     let query2 = query.clone();
     drop(query);
-    query2.iter_only(|_| {});
+    query2.run(|mut it| {
+        dbg!(it.iter_mut().flags & flecs_ecs::sys::EcsIterIsValid != 0);
+        while it.next_iter() {}
+        dbg!(it.iter_mut().flags & flecs_ecs::sys::EcsIterIsValid != 0);
+    });
     drop(query2);
 }
 
@@ -25,6 +29,6 @@ fn query_cached_destruction_lingering_references_panic() {
     let query = world.query::<&Tag>().set_cached().build();
     let query2 = query.clone();
     query.destruct();
-    query2.iter_only(|_| {});
+    query2.run(|_| {});
     drop(query2);
 }

--- a/flecs_ecs_derive/src/lib.rs
+++ b/flecs_ecs_derive/src/lib.rs
@@ -201,24 +201,29 @@ fn impl_cached_component_data_struct(
             &ONCE_LOCK
         }
 
-        fn __register_lifecycle_hooks(mut type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+        fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+            flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name>(type_hooks);
+        }
+
+        fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
             use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
-            const NEEDS_DROP: bool = <#name as flecs_ecs::core::component_registration::registration_traits::ComponentInfo>::NEEDS_DROP;
-            const IMPLS_CLONE: bool = #name::IMPLS_CLONE;
-            const IMPLS_DEFAULT: bool = #name::IMPLS_DEFAULT;
-
-            flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name>(&mut type_hooks);
-
-            if IMPLS_CLONE {
-                flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type,>(&mut type_hooks);
-            } else {
-                flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name>(&mut type_hooks);
-            }
+            const IMPLS_DEFAULT: bool =  #name::IMPLS_DEFAULT;
 
             if IMPLS_DEFAULT {
-                flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type,>(&mut type_hooks);
+                flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
+            }
+        }
+
+        fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+            const IMPLS_CLONE: bool = #name::IMPLS_CLONE;
+
+            if IMPLS_CLONE {
+                flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type, >(type_hooks);
             } else {
-                flecs_ecs::core::lifecycle_traits::register_ctor_panic_lifecycle_actions::<#name>(&mut type_hooks);
+                flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name>(
+                    type_hooks,
+                );
             }
         }
     };
@@ -433,23 +438,30 @@ fn impl_cached_component_data_enum(ast: &mut syn::DeriveInput) -> proc_macro2::T
                 &ONCE_LOCK
             }
 
-            fn __register_lifecycle_hooks(mut type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
-                use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
-                const NEEDS_DROP: bool = <#name as flecs_ecs::core::component_registration::registration_traits::ComponentInfo>::NEEDS_DROP;
-                const IMPLS_CLONE: bool = #name::IMPLS_CLONE;
-                const IMPLS_DEFAULT: bool = #name::IMPLS_DEFAULT;
-                flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name>(&mut type_hooks);
 
-                if IMPLS_CLONE {
-                    flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type,>(&mut type_hooks);
-                } else {
-                    flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name>(&mut type_hooks);
-                }
+            fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+                flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name>(type_hooks);
+            }
+
+            fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+                use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+                const IMPLS_DEFAULT: bool =  #name::IMPLS_DEFAULT;
 
                 if IMPLS_DEFAULT {
-                    flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type,>(&mut type_hooks);
+                    flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
+                }
+            }
+
+            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+                use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+                const IMPLS_CLONE: bool = #name::IMPLS_CLONE;
+
+                if IMPLS_CLONE {
+                    flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type, >(type_hooks);
                 } else {
-                    flecs_ecs::core::lifecycle_traits::register_ctor_panic_lifecycle_actions::<#name>(&mut type_hooks);
+                    flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name>(
+                        type_hooks,
+                    );
                 }
             }
     };
@@ -553,23 +565,29 @@ fn generate_component_id_impl(
                     static ONCE_LOCK: std::sync::OnceLock<flecs_ecs::core::IdComponent> = std::sync::OnceLock::new();
                     &ONCE_LOCK
                 }
-                fn __register_lifecycle_hooks(mut type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
-                    use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
-                    const NEEDS_DROP: bool = <#name<#ty> as flecs_ecs::core::component_registration::registration_traits::ComponentInfo>::NEEDS_DROP;
-                    const IMPLS_CLONE: bool = #name::<#ty>::IMPLS_CLONE;
-                    const IMPLS_DEFAULT: bool = #name::<#ty>::IMPLS_DEFAULT;
-                    flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name<#ty>>(&mut type_hooks);
+                fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+                    flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name<#ty>>(type_hooks);
+                }
 
-                    if IMPLS_CLONE {
-                        flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type,>(&mut type_hooks);
-                    } else {
-                        flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name<#ty>>(&mut type_hooks);
-                    }
+                fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+                    use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+                    const IMPLS_DEFAULT: bool =  #name::<#ty>::IMPLS_DEFAULT;
 
                     if IMPLS_DEFAULT {
-                        flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type,>(&mut type_hooks);
+                        flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
+                    }
+                }
+
+                fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+                    use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+                    const IMPLS_CLONE: bool = #name::<#ty>::IMPLS_CLONE;
+
+                    if IMPLS_CLONE {
+                        flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type, >(type_hooks);
                     } else {
-                        flecs_ecs::core::lifecycle_traits::register_ctor_panic_lifecycle_actions::<#name<#ty>>(&mut type_hooks);
+                        flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name<#ty>>(
+                            type_hooks,
+                        );
                     }
                 }
             }
@@ -599,23 +617,29 @@ fn generate_component_id_impl(
                     static ONCE_LOCK: std::sync::OnceLock<flecs_ecs::core::IdComponent> = std::sync::OnceLock::new();
                     &ONCE_LOCK
                 }
-                fn __register_lifecycle_hooks(mut type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
-                    use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
-                    const NEEDS_DROP: bool = <#name<#ty> as flecs_ecs::core::component_registration::registration_traits::ComponentInfo>::NEEDS_DROP;
-                    const IMPLS_CLONE: bool = #name::<#ty>::IMPLS_CLONE;
-                    const IMPLS_DEFAULT: bool = #name::<#ty>::IMPLS_DEFAULT;
-                    flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name<#ty>>(&mut type_hooks);
+                fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+                    flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name<#ty>>(type_hooks);
+                }
 
-                    if IMPLS_CLONE {
-                        flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type,>(&mut type_hooks);
-                    } else {
-                        flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name<#ty>>(&mut type_hooks);
-                    }
+                fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+                    use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+                    const IMPLS_DEFAULT: bool =  #name::<#ty>::IMPLS_DEFAULT;
 
                     if IMPLS_DEFAULT {
-                        flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type,>(&mut type_hooks);
+                        flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions::<<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
+                    }
+                }
+
+                fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+                    use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
+                    const IMPLS_CLONE: bool = #name::<#ty>::IMPLS_CLONE;
+
+                    if IMPLS_CLONE {
+                        flecs_ecs::core::lifecycle_traits::register_copy_lifecycle_action:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_CLONE,#name<#ty>>as flecs_ecs::core::component_registration::registration_traits::FlecsCloneType> ::Type, >(type_hooks);
                     } else {
-                        flecs_ecs::core::lifecycle_traits::register_ctor_panic_lifecycle_actions::<#name<#ty>>(&mut type_hooks);
+                        flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name<#ty>>(
+                            type_hooks,
+                        );
                     }
                 }
             }


### PR DESCRIPTION
* add const assertions around the code base (active from rust 1.79)
* add supports adding default types (warning: this is not checked until rust 1.79)
* Ctor and Copy hooks are now implemented for types that implement `Default` and `Clone`
* Support for query relationship type parameters
* Term operation validity checking, 
* Adding id is now validity checked, 
* Add `run` operation to query like objects and replace `iter`, 
* Refactor iteration code + callback registration for System and Observer
* Components are Send + Sync. WorldRef and World are Send