### PR TITLE
fix: emit should take &mut T

### DIFF
--- a/flecs_ecs/examples/flecs/observers/observer_custom_event.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_custom_event.rs
@@ -36,7 +36,7 @@ fn main() {
         .event()
         .add::<Position>()
         .target(entity)
-        .emit(&MyEvent);
+        .emit(&mut MyEvent);
 
     // Output:
     //  - MyEvent: Position: e1

--- a/flecs_ecs/examples/flecs/observers/observer_entity_event.rs
+++ b/flecs_ecs/examples/flecs/observers/observer_entity_event.rs
@@ -72,14 +72,14 @@ fn main() {
         );
     });
 
-    widget.emit(&Click);
+    widget.emit(&mut Click);
 
-    widget.emit(&Resize {
+    widget.emit(&mut Resize {
         width: 100.0,
         height: 200.0,
     });
 
-    widget.emit(&CloseRequested {
+    widget.emit(&mut CloseRequested {
         reason: CloseReason::User,
     });
 

--- a/flecs_ecs/src/core/entity_view/entity_view_const.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_const.rs
@@ -2140,7 +2140,7 @@ impl<'a> EntityView<'a> {
     /// * C++ API: `entity_view::emit`
     #[doc(alias = "entity_view::emit")]
     pub unsafe fn emit_id(self, event: impl Into<Entity>) {
-        self.world().event_id(event).target(self).emit(&());
+        self.world().event_id(event).target(self).emit(&mut ());
     }
 
     /// Emit event with an immutable payload for entity.
@@ -2153,7 +2153,7 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_view::emit`
     #[doc(alias = "entity_view::emit")]
-    pub fn emit<T: ComponentId>(self, event: &T) {
+    pub fn emit<T: ComponentId>(self, event: &mut T) {
         self.world().event().target(self).emit(event);
     }
 

--- a/flecs_ecs/src/core/event.rs
+++ b/flecs_ecs/src/core/event.rs
@@ -182,7 +182,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         self
     }
 
-    pub fn emit(&mut self, data: &T) {
+    pub fn emit(&mut self, data: &mut T) {
         let ids = &mut self.ids;
         let ids_array = &mut self.ids_array;
         let desc = &mut self.desc;


### PR DESCRIPTION
We can access &mut T with iter.param_mut(). Therefore, we should use &mut T instead of &T in the emit function.