### PR TITLE
rustdoc: Enable unstable features for docs.rs

### DIFF
--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["game-development", "api-bindings", "simulation", "development-too
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+rustdoc-args = [ "-Zunstable-options", "--generate-link-to-definition"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
 [dependencies]
 flecs_ecs_derive = { path = "../flecs_ecs_derive", version = "*"}
 flecs_ecs_sys = { path = "../flecs_ecs_sys", version = "*"}
@@ -180,3 +184,4 @@ harness = false
 name = "examples"
 path = "examples/flecs/z_ignore_main_test.rs"
 test = true
+doc-scrape-examples = true


### PR DESCRIPTION
This is the same as running:

```
RUSTDOCFLAGS="-Zunstable-options --generate-link-to-definition" cargo +nightly doc -Zunstable-options -Zrustdoc-scrape-examples
```

(And scraping examples is suported by flagging the examples as being valid for scraping in the `examples` configuration.)