### PR TITLE
When building for docs.rs, show features required

### DIFF
--- a/flecs_ecs/src/lib.rs
+++ b/flecs_ecs/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(all(
     feature = "flecs_force_build_release_c",


### PR DESCRIPTION
This requires running nightly and having the `docsrs` cfg set.