### PR TITLE
Add `cargo +nightly make fdocs`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -56,3 +56,11 @@ workspace = false
 script = { file = "${CARGO_MAKE_WORKING_DIRECTORY}/scripts/fbench_log.sh", absolute_path = true }
 dependencies = ["chmod"]
 workspace = false
+
+# When updating this, see if any docs.rs configs in `Cargo.toml` files need updating.
+[tasks.fdocs]
+condition = { channels = ["nightly"] }
+env = { "RUSTDOCFLAGS" = "--cfg docsrs -Zunstable-options --generate-link-to-definition" }
+command = "cargo"
+args = ["doc", "-Zunstable-options", "-Zrustdoc-scrape-examples", "${@}"]
+workspace = false

--- a/flecs_ecs/Cargo.toml
+++ b/flecs_ecs/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["game-development", "api-bindings", "simulation", "development-too
 [lints]
 workspace = true
 
+# When updating this, also update the `fdocs` task in `Makefile.toml`
 [package.metadata.docs.rs]
 rustdoc-args = [ "-Zunstable-options", "--generate-link-to-definition"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]


### PR DESCRIPTION
This also passes additional arguments to the task, so you can do things like:

```
cargo +nightly make fdocs --open
```

This runs in a similar configuration to what is done for docs.rs