### PR TITLE
`Archetype` doesn't need to impl `Deref`

### DIFF
--- a/flecs_ecs/src/core/archetype.rs
+++ b/flecs_ecs/src/core/archetype.rs
@@ -3,7 +3,6 @@
 use std::{
     ffi::CStr,
     fmt::{Debug, Display},
-    ops::Deref,
     ptr::NonNull,
 };
 
@@ -138,13 +137,5 @@ impl<'a> Archetype<'a> {
         } else {
             None
         }
-    }
-}
-
-impl<'a> Deref for Archetype<'a> {
-    type Target = [Id];
-
-    fn deref(&self) -> &Self::Target {
-        self.type_vec
     }
 }

--- a/flecs_ecs/tests/flecs/entity_test.rs
+++ b/flecs_ecs/tests/flecs/entity_test.rs
@@ -1033,13 +1033,13 @@ fn entity_get_type() {
     {
         let type_2 = entity.archetype();
         assert_eq!(type_2.count(), 1);
-        assert_eq!(type_2[0], world.id_from::<Position>());
+        assert_eq!(type_2.get(0).unwrap(), world.id_from::<Position>());
     }
 
     entity.set(Velocity { x: 0, y: 0 });
     let type_3 = entity.archetype();
     assert_eq!(type_3.count(), 2);
-    assert_eq!(type_3[1], world.id_from::<Velocity>());
+    assert_eq!(type_3.get(1).unwrap(), world.id_from::<Velocity>());
 }
 
 #[test]


### PR DESCRIPTION
This same data can be obtained via `Archetype::as_slice()`.