### PR TITLE
app::enable_stats: Add link in docs, cfg on flecs_stats.

### DIFF
--- a/flecs_ecs/src/addons/app.rs
+++ b/flecs_ecs/src/addons/app.rs
@@ -123,8 +123,10 @@ impl<'a> App<'a> {
     ///
     /// # See also
     ///
+    /// * [`addons::stats`](crate::addons::stats)
     /// * C++ API: `app_builder::enable_stats`
     #[doc(alias = "app_builder::enable_stats")]
+    #[cfg(feature = "flecs_stats")]
     pub fn enable_stats(&mut self, enable: bool) -> &mut Self {
         self.desc.enable_stats = enable;
         self


### PR DESCRIPTION
Like `app::enable_rest`, this shouldn't be available without the corresponding feature.