### PR TITLE
More doc cross-linking, expose fewer `new` functions

### DIFF
--- a/flecs_ecs/benches/flecs/event_bench.rs
+++ b/flecs_ecs/benches/flecs/event_bench.rs
@@ -22,7 +22,7 @@ pub fn event_emit(criterion: &mut Criterion) {
                 let start = Instant::now();
                 for _ in 0..iters {
                     unsafe {
-                        EventBuilder::<()>::new_untyped(&world, evt)
+                        world.event_id(evt)
                             .add::<T1>()
                             .table(table, 0, 0)
                             .emit(&());
@@ -62,7 +62,7 @@ pub fn event_emit_propagate(criterion: &mut Criterion) {
                 let start = Instant::now();
                 for _ in 0..iters {
                     unsafe {
-                        EventBuilder::<()>::new_untyped(&world, evt)
+                        world.event_id(evt)
                             .add::<T1>()
                             .table(root_table, 0, 0)
                             .emit(&());

--- a/flecs_ecs/src/addons/app.rs
+++ b/flecs_ecs/src/addons/app.rs
@@ -6,6 +6,8 @@ use crate::core::*;
 use crate::sys;
 
 /// Application interface.
+///
+/// These are typically constructed via [`World::app()`]
 pub struct App<'a> {
     world: WorldRef<'a>,
     desc: sys::ecs_app_desc_t,
@@ -23,7 +25,7 @@ impl<'a> App<'a> {
     /// * [`World::app()`]
     /// * C++ API: `app_builder::app_builder`
     #[doc(alias = "app_builder::app_builder")]
-    pub fn new(world: impl IntoWorld<'a>) -> Self {
+    pub(crate) fn new(world: impl IntoWorld<'a>) -> Self {
         let mut obj = Self {
             world: world.world(),
             desc: sys::ecs_app_desc_t::default(),

--- a/flecs_ecs/src/addons/pipeline/mod.rs
+++ b/flecs_ecs/src/addons/pipeline/mod.rs
@@ -65,7 +65,7 @@ where
     ///
     /// * C++ API: `pipeline::pipeline`
     #[doc(alias = "pipeline::pipeline")]
-    pub fn new(world: impl IntoWorld<'a>, desc: sys::ecs_pipeline_desc_t) -> Self {
+    pub(crate) fn new(world: impl IntoWorld<'a>, desc: sys::ecs_pipeline_desc_t) -> Self {
         let entity = EntityView::new(world.world());
         let mut pipeline = Self {
             entity,

--- a/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
+++ b/flecs_ecs/src/addons/pipeline/pipeline_builder.rs
@@ -26,7 +26,7 @@ where
     T: QueryTuple,
 {
     /// Create a new pipeline builder
-    pub fn new(world: &'a World) -> Self {
+    pub(crate) fn new(world: &'a World) -> Self {
         let desc = Default::default();
         let mut obj = Self {
             desc,
@@ -44,7 +44,7 @@ where
     }
 
     /// Create a new pipeline builder with an associated entity
-    pub fn new_w_entity(world: &'a World, entity: impl Into<Entity>) -> Self {
+    pub(crate) fn new_w_entity(world: &'a World, entity: impl Into<Entity>) -> Self {
         let mut obj = Self::new(world);
         obj.desc.entity = *entity.into();
         obj
@@ -96,7 +96,7 @@ where
     }
 
     /// Create a new pipeline builder with a name
-    pub fn new_named(world: &'a World, name: &str) -> Self {
+    pub(crate) fn new_named(world: &'a World, name: &str) -> Self {
         let name = compact_str::format_compact!("{}\0", name);
 
         let mut obj = Self {

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -22,7 +22,7 @@ where
     T: QueryTuple,
 {
     /// Create a new system builder
-    pub fn new(world: &'a World) -> Self {
+    pub(crate) fn new(world: &'a World) -> Self {
         let mut obj = Self {
             desc: Default::default(),
             term_builder: TermBuilder::default(),
@@ -78,7 +78,7 @@ where
     }
 
     /// Create a new system builder with a name
-    pub fn new_named(world: &'a World, name: &str) -> Self {
+    pub(crate) fn new_named(world: &'a World, name: &str) -> Self {
         let name = compact_str::format_compact!("{}\0", name);
 
         let mut obj = Self {

--- a/flecs_ecs/src/core/archetype.rs
+++ b/flecs_ecs/src/core/archetype.rs
@@ -47,7 +47,7 @@ impl<'a> Debug for Archetype<'a> {
 }
 
 impl<'a> Archetype<'a> {
-    pub fn new(world: impl IntoWorld<'a>, type_vec: &'a [Id]) -> Self {
+    pub(crate) fn new(world: impl IntoWorld<'a>, type_vec: &'a [Id]) -> Self {
         Archetype {
             world: world.world(),
             type_vec,
@@ -55,7 +55,11 @@ impl<'a> Archetype<'a> {
         }
     }
 
-    pub fn new_locked(world: impl IntoWorld<'a>, type_vec: &'a [Id], lock: TableLock<'a>) -> Self {
+    pub(crate) fn new_locked(
+        world: impl IntoWorld<'a>,
+        type_vec: &'a [Id],
+        lock: TableLock<'a>,
+    ) -> Self {
         Archetype {
             world: world.world(),
             type_vec,

--- a/flecs_ecs/src/core/entity_view/entity_view_const.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_const.rs
@@ -2099,7 +2099,7 @@ impl<'a> EntityView<'a> {
 
 // Event mixin
 impl<'a> EntityView<'a> {
-    /// Emit event for entity
+    /// Emit event for entity.
     ///
     /// # Safety
     /// Caller must ensure that any type associated with `event` is a ZST
@@ -2110,6 +2110,13 @@ impl<'a> EntityView<'a> {
     ///
     /// # See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue_id()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_view::emit`
     #[doc(alias = "entity_view::emit")]
     pub unsafe fn emit_id(self, event: impl Into<Entity>) {
@@ -2124,6 +2131,13 @@ impl<'a> EntityView<'a> {
     ///
     /// # See also
     ///
+    /// * [`EntityView::emit_id()`]
+    /// * [`EntityView::enqueue_id()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_view::emit`
     #[doc(alias = "entity_view::emit")]
     pub fn emit<T: ComponentId>(self, event: &T) {
@@ -2141,13 +2155,20 @@ impl<'a> EntityView<'a> {
     ///
     /// # See also
     ///
+    /// * [`EntityView::emit_id()`]
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_view::enqueue`
     #[doc(alias = "entity_view::enqueue")]
     pub unsafe fn enqueue_id(self, event: impl Into<Entity>) {
         self.world().event_id(event).entity(self).enqueue(());
     }
 
-    /// enqueue event for entity.
+    /// Enqueue event for entity.
     ///
     /// # Type Parameters
     ///
@@ -2169,6 +2190,13 @@ impl<'a> EntityView<'a> {
     ///
     /// # See also
     ///
+    /// * [`EntityView::emit_id()`]
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue_id()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_view::enqueue`
     #[doc(alias = "entity_view::enqueue")]
     pub fn enqueue<T: ComponentId>(self, event: T) {
@@ -2190,6 +2218,13 @@ impl<'a> EntityView<'a> {
     ///
     /// See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe_entity()`]
+    /// * [`EntityView::observe_payload_entity()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_builder::observe`
     #[doc(alias = "entity_builder::observe")]
     pub fn observe<C>(self, func: impl FnMut() + 'static) -> Self
@@ -2235,6 +2270,13 @@ impl<'a> EntityView<'a> {
     ///
     /// See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload_entity()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_builder::observe`
     #[doc(alias = "entity_builder::observe")]
     pub fn observe_entity<C>(self, func: impl FnMut(&mut EntityView) + 'static) -> Self
@@ -2280,6 +2322,13 @@ impl<'a> EntityView<'a> {
     ///
     /// See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe_entity()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload_entity()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_builder::observe`
     #[doc(alias = "entity_builder::observe")]
     pub fn observe_payload<C>(self, func: impl FnMut(&C) + 'static) -> Self
@@ -2325,6 +2374,13 @@ impl<'a> EntityView<'a> {
     ///
     /// See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`EntityView::observe_entity()`]
+    /// * [`EntityView::observe()`]
+    /// * [`EntityView::observe_payload()`]
+    /// * [`World::event_id()`]
+    /// * [`World::event()`]
     /// * C++ API: `entity_builder::observe`
     #[doc(alias = "entity_builder::observe")]
     pub fn observe_payload_entity<C>(self, func: impl FnMut(&mut EntityView, &C) + 'static) -> Self

--- a/flecs_ecs/src/core/event.rs
+++ b/flecs_ecs/src/core/event.rs
@@ -15,6 +15,11 @@ use crate::sys;
 /// Ensures the use of appropriate data types for events, enhancing type safety and data integrity.
 /// This design aims to prevent the utilization of incompatible components as event data,
 /// thereby ensuring greater explicitness and correctness in event handling.
+///
+/// # See also
+///
+/// * [`World::event()`]
+/// * [`World::event_id()`]
 pub struct EventBuilder<'a, T = ()> {
     pub world: WorldRef<'a>,
     pub(crate) desc: sys::ecs_event_desc_t,
@@ -24,13 +29,14 @@ pub struct EventBuilder<'a, T = ()> {
 }
 
 impl<'a, T: ComponentId> EventBuilder<'a, T> {
-    /// Create a new typed `EventBuilder`
+    /// Create a new typed [`EventBuilder`].
     ///
     /// # See also
     ///
+    /// * [`EventBuilder::new_untyped()`]
     /// * C++ API: `event_builder_typed::event_builder_typed`
     #[doc(alias = "event_builder_typed::event_builder_typed")]
-    pub fn new(world: impl IntoWorld<'a>) -> Self {
+    pub(crate) fn new(world: impl IntoWorld<'a>) -> Self {
         let mut obj = Self {
             world: world.world(),
             desc: Default::default(),
@@ -42,9 +48,10 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         obj
     }
 
-    /// Create a new (untyped) `EventBuilder`
+    /// Create a new (untyped) [`EventBuilder`].
     ///
     /// # Safety
+    ///
     /// Caller must ensure either that `event` represents a ZST
     /// or the event data is set to point to the appropriate type
     ///
@@ -55,9 +62,10 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
     ///
     /// # See also
     ///
+    /// * [`EventBuilder::new()`]
     /// * C++ API: `event_builder_base::event_builder_base`
     #[doc(alias = "event_builder_base::event_builder_base")]
-    pub unsafe fn new_untyped(
+    pub(crate) unsafe fn new_untyped(
         world: impl IntoWorld<'a>,
         event: impl Into<Entity>,
     ) -> EventBuilder<'a, ()> {
@@ -72,7 +80,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         obj
     }
 
-    /// Add component id or pair to emit for the event
+    /// Add component id or pair to emit for the event.
     ///
     /// # Arguments
     ///
@@ -94,7 +102,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         self
     }
 
-    /// Add component to emit for the event
+    /// Add component to emit for the event.
     ///
     /// # Type parameters
     ///
@@ -112,7 +120,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         self.add_id(C::get_id(world))
     }
 
-    /// Add a pair of components to emit for the event
+    /// Add a pair of components to emit for the event.
     ///
     /// # Type parameters
     ///
@@ -143,7 +151,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         self.add_id(ecs_pair(*first.into(), Second::id(world)))
     }
 
-    /// Set the entity to emit for the event
+    /// Set the entity to emit for the event.
     ///
     /// # Arguments
     ///
@@ -159,7 +167,7 @@ impl<'a, T: ComponentId> EventBuilder<'a, T> {
         self
     }
 
-    /// Set the table to emit for the event
+    /// Set the table to emit for the event.
     ///
     /// # Arguments
     ///

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -3711,6 +3711,9 @@ impl World {
     ///
     /// # See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`World::event()`]
     /// * C++ API: `world::event`
     #[doc(alias = "world::event")]
     pub unsafe fn event_id(&self, event: impl Into<Entity>) -> EventBuilder<()> {
@@ -3729,6 +3732,9 @@ impl World {
     ///
     /// # See also
     ///
+    /// * [`EntityView::emit()`]
+    /// * [`EntityView::enqueue()`]
+    /// * [`World::event_id()`]
     /// * C++ API: `world::event`
     #[doc(alias = "world::event")]
     pub fn event<T: ComponentId>(&self) -> EventBuilder<T> {
@@ -3769,6 +3775,7 @@ impl World {
     ///
     /// # See also
     ///
+    /// * [`World::new_observer()`]
     /// * [`World::observer_id()`]
     /// * [`World::observer_named()`]
     /// * C++ API: `world::observer`
@@ -3808,6 +3815,7 @@ impl World {
     ///
     /// # See also
     ///
+    /// * [`World::new_observer()`]
     /// * [`World::observer()`]
     /// * [`World::observer_id()`]
     /// * C++ API: `world::observer`


### PR DESCRIPTION
Most `new` functions aren't meant for use outside of the crate as they're used by builders instead which are accessed via the `World`.