### PR TITLE
fix: macros correctly use u32 instead of i32 for indexing

### DIFF
--- a/flecs_ecs/tests/flecs/system_test.rs
+++ b/flecs_ecs/tests/flecs/system_test.rs
@@ -1934,7 +1934,6 @@ fn system_un_instanced_query_w_base_each() {
     });
 }
 
-#[ignore = "fix this test"]
 #[test]
 fn system_instanced_query_w_singleton_iter() {
     let world = World::new();
@@ -1972,8 +1971,8 @@ fn system_instanced_query_w_singleton_iter() {
                 assert!(it.count() > 1);
 
                 for i in it.iter() {
-                    p[i].x += v[i].x;
-                    p[i].y += v[i].y;
+                    p[i].x += v[0].x;
+                    p[i].y += v[0].y;
                     assert!(it.entity(i) == s[i].value);
                     world.get::<&mut Count>(|c| {
                         c.0 += 1;
@@ -2049,8 +2048,8 @@ fn system_instanced_query_w_singleton_each_macro() {
                 assert!(it.count() > 1);
 
                 for i in it.iter() {
-                    p[i].x += v[i].x;
-                    p[i].y += v[i].y;
+                    p[i].x += v[0].x;
+                    p[i].y += v[0].y;
                     assert!(it.entity(i) == s[i].value);
                     world.get::<&mut Count>(|c| {
                         c.0 += 1;

--- a/flecs_ecs/tests/flecs/system_test.rs
+++ b/flecs_ecs/tests/flecs/system_test.rs
@@ -50,18 +50,17 @@ fn system_iter_macro() {
         .entity()
         .set(Position { x: 10, y: 20 })
         .set(Velocity { x: 1, y: 2 });
-    
-    system!(world, &mut Position, &Velocity)
-        .run(|mut it| {
-            while it.next() {
-                let mut p = it.field::<Position>(0).unwrap();
-                let v = it.field::<Velocity>(1).unwrap();
-                for i in it.iter() {
-                    p[i].x += v[i].x;
-                    p[i].y += v[i].y;
-                }
+
+    system!(world, &mut Position, &Velocity).run(|mut it| {
+        while it.next() {
+            let mut p = it.field::<Position>(0).unwrap();
+            let v = it.field::<Velocity>(1).unwrap();
+            for i in it.iter() {
+                p[i].x += v[i].x;
+                p[i].y += v[i].y;
             }
-        });
+        }
+    });
 
     world.progress();
 

--- a/flecs_ecs_derive/src/lib.rs
+++ b/flecs_ecs_derive/src/lib.rs
@@ -1305,7 +1305,7 @@ fn expand_dsl(terms: &mut [Term]) -> (TokenStream, Vec<TokenStream>) {
         .iter()
         .enumerate()
         .filter_map(|(i, t)| {
-            let index = i as i32;
+            let index = i as u32;
             let mut ops = Vec::new();
             let mut needs_accessor = false;
             let iter_term = i < iter_terms.len();


### PR DESCRIPTION
Fixes #126 