### PR TITLE
Remove some type aliases for sys types.

### DIFF
--- a/flecs_ecs/examples/flecs/queries/query_group_by_callbacks.rs
+++ b/flecs_ecs/examples/flecs/queries/query_group_by_callbacks.rs
@@ -1,6 +1,7 @@
 use crate::z_ignore_test_common::*;
 
 use flecs_ecs::prelude::*;
+use flecs_ecs::sys;
 use std::ffi::c_void;
 use std::sync::Mutex;
 
@@ -33,7 +34,7 @@ pub struct Group;
 
 // callbacks need to be extern "C" to be callable from C
 extern "C" fn callback_group_create(
-    world: *mut WorldT,
+    world: *mut sys::ecs_world_t,
     group_id: u64,
     _group_by_ctx: *mut c_void,
 ) -> *mut c_void {
@@ -56,7 +57,7 @@ extern "C" fn callback_group_create(
 
 // callbacks need to be extern "C" to be callable from C
 extern "C" fn callback_group_delete(
-    world: *mut WorldT,
+    world: *mut sys::ecs_world_t,
     group_id: u64,
     _ctx: *mut c_void,
     _group_by_ctx: *mut c_void,

--- a/flecs_ecs/examples/flecs/queries/query_group_by_custom.rs
+++ b/flecs_ecs/examples/flecs/queries/query_group_by_custom.rs
@@ -1,9 +1,8 @@
 use crate::z_ignore_test_common::*;
 
 use flecs_ecs::prelude::*;
+use flecs_ecs::sys;
 use std::ffi::c_void;
-
-use flecs_ecs_sys::ecs_search;
 
 #[derive(Debug, Component)]
 pub struct Position {
@@ -28,16 +27,16 @@ pub struct Group;
 
 // callbacks need to be extern "C" to be callable from C
 extern "C" fn callback_group_by_relationship(
-    world: *mut WorldT,
-    table: *mut TableT,
+    world: *mut sys::ecs_world_t,
+    table: *mut sys::ecs_table_t,
     id: u64,
     _group_by_ctx: *mut c_void,
 ) -> u64 {
-    // Use ecs_search to find the target for the relationship in the table
-    let mut match_id: IdT = Default::default();
+    // Use sys::ecs_search to find the target for the relationship in the table
+    let mut match_id: sys::ecs_id_t = Default::default();
     let world = unsafe { WorldRef::from_ptr(world) };
     let id = IdView::new_from(world, (id, flecs::Wildcard::ID)).id();
-    if unsafe { ecs_search(world.world_ptr_mut(), table, *id, &mut match_id) } != -1 {
+    if unsafe { sys::ecs_search(world.world_ptr_mut(), table, *id, &mut match_id) } != -1 {
         *IdView::new_from(world, match_id).second_id().id() // First, Second or Third
     } else {
         0

--- a/flecs_ecs/src/addons/meta/declarations.rs
+++ b/flecs_ecs/src/addons/meta/declarations.rs
@@ -40,23 +40,23 @@ pub struct EcsBitmask {
     value: u32,
 }
 
-pub const BOOL: EntityT = ECS_BOOL_T;
-pub const CHAR: EntityT = ECS_CHAR_T;
-pub const BYTE: EntityT = ECS_BYTE_T;
-pub const U32: EntityT = ECS_U32_T;
-pub const U64: EntityT = ECS_U64_T;
-pub const U_PTR: EntityT = ECS_UPTR_T;
-pub const I8: EntityT = ECS_I8_T;
-pub const I16: EntityT = ECS_I16_T;
-pub const I32: EntityT = ECS_I32_T;
-pub const I64: EntityT = ECS_I64_T;
-pub const I_PTR: EntityT = ECS_IPTR_T;
-pub const F32: EntityT = ECS_F32_T;
-pub const F64: EntityT = ECS_F64_T;
-pub const STRING: EntityT = ECS_STRING_T;
-pub const ENTITY: EntityT = ECS_ENTITY_T;
-pub const CONSTANT: EntityT = ECS_CONSTANT;
-pub const QUANTITY: EntityT = ECS_QUANTITY;
+pub const BOOL: sys::ecs_entity_t = ECS_BOOL_T;
+pub const CHAR: sys::ecs_entity_t = ECS_CHAR_T;
+pub const BYTE: sys::ecs_entity_t = ECS_BYTE_T;
+pub const U32: sys::ecs_entity_t = ECS_U32_T;
+pub const U64: sys::ecs_entity_t = ECS_U64_T;
+pub const U_PTR: sys::ecs_entity_t = ECS_UPTR_T;
+pub const I8: sys::ecs_entity_t = ECS_I8_T;
+pub const I16: sys::ecs_entity_t = ECS_I16_T;
+pub const I32: sys::ecs_entity_t = ECS_I32_T;
+pub const I64: sys::ecs_entity_t = ECS_I64_T;
+pub const I_PTR: sys::ecs_entity_t = ECS_IPTR_T;
+pub const F32: sys::ecs_entity_t = ECS_F32_T;
+pub const F64: sys::ecs_entity_t = ECS_F64_T;
+pub const STRING: sys::ecs_entity_t = ECS_STRING_T;
+pub const ENTITY: sys::ecs_entity_t = ECS_ENTITY_T;
+pub const CONSTANT: sys::ecs_entity_t = ECS_CONSTANT;
+pub const QUANTITY: sys::ecs_entity_t = ECS_QUANTITY;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum EcsTypeKind {

--- a/flecs_ecs/src/addons/meta/opaque.rs
+++ b/flecs_ecs/src/addons/meta/opaque.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_char, c_void};
 
 use crate::core::*;
-use crate::sys::*;
+use crate::sys::{self, *};
 
 type AssignBoolFn<T> = extern "C" fn(*mut T, bool);
 type AssignCharFn<T> = extern "C" fn(*mut T, i8);
@@ -10,7 +10,7 @@ type AssignUIntFn<T> = extern "C" fn(*mut T, u64);
 type AssignFloatFn<T> = extern "C" fn(*mut T, f32);
 //todo!("replace with idiomatic rust equivalent of c_char. might need changes to flecs")
 type AssignStringFn<T> = extern "C" fn(*mut T, *const c_char);
-type AssignEntityFn<T> = extern "C" fn(*mut T, *mut WorldT, EntityT);
+type AssignEntityFn<T> = extern "C" fn(*mut T, *mut sys::ecs_world_t, sys::ecs_entity_t);
 type AssignNullFn<T> = extern "C" fn(*mut T);
 type ClearFn<T> = extern "C" fn(*mut T);
 //todo!("still have to do ensure_element function for collections")

--- a/flecs_ecs/src/addons/stats.rs
+++ b/flecs_ecs/src/addons/stats.rs
@@ -1,5 +1,5 @@
 //! Periodically tracks statistics for the world and systems.
-use crate::core::{EntityT, IntoWorld, World};
+use crate::core::{IntoWorld, World};
 use crate::sys;
 
 #[cfg(feature = "flecs_module")]
@@ -61,19 +61,19 @@ where
         static INDEX: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(u32::MAX);
         Self::get_or_init_index(&INDEX)
     }
-    fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<sys::EcsWorldStats>(
             type_hooks,
         );
     }
-    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_default_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_DEFAULT: bool = sys::EcsWorldStats::IMPLS_DEFAULT;
         if IMPLS_DEFAULT {
             flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,sys::EcsWorldStats>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
         }
     }
-    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_CLONE: bool = sys::EcsWorldStats::IMPLS_CLONE;
         if IMPLS_CLONE {
@@ -118,19 +118,19 @@ where
         static INDEX: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(u32::MAX);
         Self::get_or_init_index(&INDEX)
     }
-    fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<sys::EcsPipelineStats>(
             type_hooks,
         );
     }
-    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_default_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_DEFAULT: bool = sys::EcsPipelineStats::IMPLS_DEFAULT;
         if IMPLS_DEFAULT {
             flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,sys::EcsPipelineStats>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
         }
     }
-    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_CLONE: bool = sys::EcsPipelineStats::IMPLS_CLONE;
         if IMPLS_CLONE {
@@ -175,19 +175,19 @@ where
         static INDEX: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(u32::MAX);
         Self::get_or_init_index(&INDEX)
     }
-    fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<sys::EcsWorldSummary>(
             type_hooks,
         );
     }
-    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_default_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_DEFAULT: bool = sys::EcsWorldSummary::IMPLS_DEFAULT;
         if IMPLS_DEFAULT {
             flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,sys::EcsWorldSummary>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
         }
     }
-    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_CLONE: bool = sys::EcsWorldSummary::IMPLS_CLONE;
         if IMPLS_CLONE {
@@ -232,19 +232,19 @@ where
         static INDEX: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(u32::MAX);
         Self::get_or_init_index(&INDEX)
     }
-    fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<sys::EcsSystemStats>(
             type_hooks,
         );
     }
-    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_default_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_DEFAULT: bool = sys::EcsSystemStats::IMPLS_DEFAULT;
         if IMPLS_DEFAULT {
             flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,sys::EcsSystemStats>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
         }
     }
-    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_CLONE: bool = sys::EcsSystemStats::IMPLS_CLONE;
         if IMPLS_CLONE {
@@ -286,17 +286,17 @@ where
         static INDEX: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(u32::MAX);
         Self::get_or_init_index(&INDEX)
     }
-    fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<Stats>(type_hooks);
     }
-    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_default_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_DEFAULT: bool = Stats::IMPLS_DEFAULT;
         if IMPLS_DEFAULT {
             flecs_ecs::core::lifecycle_traits::register_ctor_lifecycle_actions:: <<flecs_ecs::core::component_registration::registration_types::ConditionalTypeSelector<IMPLS_DEFAULT,Stats>as flecs_ecs::core::component_registration::registration_traits::FlecsDefaultType> ::Type, >(type_hooks);
         }
     }
-    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
         const IMPLS_CLONE: bool = Stats::IMPLS_CLONE;
         if IMPLS_CLONE {
@@ -310,7 +310,7 @@ where
 
     fn __register_or_get_id<'a, const MANUAL_REGISTRATION_CHECK: bool>(
         world: impl IntoWorld<'a>,
-    ) -> EntityT {
+    ) -> sys::ecs_entity_t {
         Self::__register_or_get_id_named::<MANUAL_REGISTRATION_CHECK>(world, "flecs::stats")
     }
 }

--- a/flecs_ecs/src/addons/system/system_builder.rs
+++ b/flecs_ecs/src/addons/system/system_builder.rs
@@ -123,7 +123,7 @@ where
     #[doc(alias = "system_builder_i::kind")]
     pub fn kind_id(&mut self, phase: impl Into<Entity>) -> &mut Self {
         let phase = *phase.into();
-        let current_phase: EntityT = unsafe {
+        let current_phase: sys::ecs_entity_t = unsafe {
             sys::ecs_get_target(self.world_ptr_mut(), self.desc.entity, ECS_DEPENDS_ON, 0)
         };
         unsafe {

--- a/flecs_ecs/src/addons/system/system_runner_fluent.rs
+++ b/flecs_ecs/src/addons/system/system_runner_fluent.rs
@@ -7,7 +7,7 @@ use crate::sys;
 
 pub struct SystemRunnerFluent<'a> {
     stage: WorldRef<'a>,
-    id: EntityT,
+    id: sys::ecs_entity_t,
     stage_current: i32,
     stage_count: i32,
     offset: i32,

--- a/flecs_ecs/src/core/c_types.rs
+++ b/flecs_ecs/src/core/c_types.rs
@@ -8,24 +8,6 @@ use crate::sys;
 pub const RUST_ecs_id_FLAGS_MASK: u64 = 0xFF << 60;
 pub const RUST_ECS_COMPONENT_MASK: u64 = !RUST_ecs_id_FLAGS_MASK;
 
-pub type WorldT = sys::ecs_world_t;
-pub type WorldInfoT = sys::ecs_world_info_t;
-pub type IdT = sys::ecs_id_t;
-pub type EntityT = sys::ecs_entity_t;
-pub type TypeT = sys::ecs_type_t;
-pub type TableT = sys::ecs_table_t;
-pub type ObserverT = sys::ecs_observer_t;
-pub type QueryT = sys::ecs_query_t;
-pub type QueryGroupInfoT = sys::ecs_query_group_info_t;
-pub type RefT = sys::ecs_ref_t;
-pub type IterT = sys::ecs_iter_t;
-pub type TypeInfoT = sys::ecs_type_info_t;
-pub type TypeHooksT = sys::ecs_type_hooks_t;
-pub type TypeKindT = sys::ecs_type_kind_t;
-pub type Flags32T = sys::ecs_flags32_t;
-pub type TermRefT = sys::ecs_term_ref_t;
-pub type TermT = sys::ecs_term_t;
-pub type PrimitiveKindT = sys::ecs_primitive_kind_t;
 pub type FTimeT = f32;
 
 pub static SEPARATOR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"::\0") };
@@ -538,25 +520,25 @@ macro_rules! impl_component_traits_binding_type_w_id {
                     std::sync::atomic::AtomicU32::new(u32::MAX);
                 Self::get_or_init_index(&INDEX)
             }
-            fn __register_lifecycle_hooks(type_hooks: &mut TypeHooksT) {
+            fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
                 register_lifecycle_actions::<$name>(type_hooks);
             }
-            fn __register_default_hooks(_type_hooks: &mut TypeHooksT) {}
+            fn __register_default_hooks(_type_hooks: &mut sys::ecs_type_hooks_t) {}
 
-            fn __register_clone_hooks(type_hooks: &mut TypeHooksT) {
+            fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
                 register_copy_lifecycle_action::<$name>(type_hooks);
             }
 
             fn __register_or_get_id<'a, const MANUAL_REGISTRATION_CHECK: bool>(
                 _world: impl IntoWorld<'a>,
-            ) -> EntityT {
+            ) -> sys::ecs_entity_t {
                 $id
             }
 
             fn __register_or_get_id_named<'a, const MANUAL_REGISTRATION_CHECK: bool>(
                 _world: impl IntoWorld<'a>,
                 _name: &str,
-            ) -> EntityT {
+            ) -> sys::ecs_entity_t {
                 $id
             }
 
@@ -564,7 +546,7 @@ macro_rules! impl_component_traits_binding_type_w_id {
                 true
             }
 
-            fn id<'a>(_world: impl IntoWorld<'a>) -> IdT {
+            fn id<'a>(_world: impl IntoWorld<'a>) -> sys::ecs_id_t {
                 $id
             }
         }

--- a/flecs_ecs/src/core/cloned_tuple.rs
+++ b/flecs_ecs/src/core/cloned_tuple.rs
@@ -137,7 +137,7 @@ where
     fn populate_array_ptrs<'a, const SHOULD_PANIC: bool>(
         world: impl IntoWorld<'a>, record: *const ecs_record_t, components: &mut [*mut c_void]
     ) -> bool {
-        let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut WorldT };
+        let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut sys::ecs_world_t };
         let table = unsafe { (*record).table };
         let mut has_all_components = true;
 
@@ -230,7 +230,7 @@ macro_rules! impl_cloned_tuple {
                 world: impl IntoWorld<'a>, record: *const ecs_record_t, components: &mut [*mut c_void]
             ) -> bool {
 
-                let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut WorldT };
+                let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut sys::ecs_world_t };
                 let world_ref = world.world();
                 let table = unsafe { (*record).table };
                 let mut index : usize = 0;

--- a/flecs_ecs/src/core/component_registration/helpers.rs
+++ b/flecs_ecs/src/core/component_registration/helpers.rs
@@ -3,9 +3,10 @@
 use std::ffi::c_char;
 
 use crate::core::*;
+use crate::sys;
 
 pub(crate) fn create_component_desc(
-    entity: EntityT,
+    entity: sys::ecs_entity_t,
     type_info: flecs_ecs_sys::ecs_type_info_t,
 ) -> flecs_ecs_sys::ecs_component_desc_t {
     flecs_ecs_sys::ecs_component_desc_t {

--- a/flecs_ecs/src/core/component_registration/registration.rs
+++ b/flecs_ecs/src/core/component_registration/registration.rs
@@ -27,7 +27,7 @@ where
 
 #[inline(always)]
 /// attempts to register the component with the world. If it's already registered, it does nothing.
-pub(crate) fn try_register_component<'a, T>(world: impl IntoWorld<'a>) -> EntityT
+pub(crate) fn try_register_component<'a, T>(world: impl IntoWorld<'a>) -> sys::ecs_entity_t
 where
     T: ComponentId,
 {
@@ -35,7 +35,10 @@ where
 }
 
 #[inline(always)]
-pub(crate) fn try_register_component_named<'a, T>(world: impl IntoWorld<'a>, name: &str) -> EntityT
+pub(crate) fn try_register_component_named<'a, T>(
+    world: impl IntoWorld<'a>,
+    name: &str,
+) -> sys::ecs_entity_t
 where
     T: ComponentId,
 {
@@ -45,7 +48,7 @@ where
 }
 
 /// registers enum fields with the world.
-pub(crate) fn register_enum_data<T>(world: *mut WorldT, id: EntityT)
+pub(crate) fn register_enum_data<T>(world: *mut sys::ecs_world_t, id: sys::ecs_entity_t)
 where
     T: ComponentId,
 {
@@ -55,7 +58,7 @@ where
 
     for (index, enum_item) in T::UnderlyingEnumType::iter().enumerate() {
         let name = enum_item.name_cstr();
-        let entity_id: EntityT = unsafe {
+        let entity_id: sys::ecs_entity_t = unsafe {
             sys::ecs_cpp_enum_constant_register(
                 world,
                 id,
@@ -71,7 +74,10 @@ where
 }
 
 /// registers the component with the world.
-pub(crate) fn register_component_data_named<T>(world: *mut WorldT, name: *const c_char) -> EntityT
+pub(crate) fn register_component_data_named<T>(
+    world: *mut sys::ecs_world_t,
+    name: *const c_char,
+) -> sys::ecs_entity_t
 where
     T: ComponentId,
 {
@@ -94,7 +100,7 @@ where
 }
 
 /// registers the component with the world.
-pub(crate) fn register_component_data<T>(world: *mut WorldT) -> EntityT
+pub(crate) fn register_component_data<T>(world: *mut sys::ecs_world_t) -> sys::ecs_entity_t
 where
     T: ComponentId,
 {
@@ -114,9 +120,9 @@ where
 
 /// registers the component with the world.
 pub(crate) fn register_componment_data_explicit<T>(
-    world: *mut WorldT,
+    world: *mut sys::ecs_world_t,
     name: *const c_char,
-) -> EntityT
+) -> sys::ecs_entity_t
 where
     T: ComponentId,
 {

--- a/flecs_ecs/src/core/component_registration/registration_traits.rs
+++ b/flecs_ecs/src/core/component_registration/registration_traits.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::core::*;
+use crate::sys;
 
 /// Indicates that the type is a tag component. A tag component is a component that does not have any data. Is a zero-sized type.
 pub trait TagComponent {}
@@ -96,7 +97,7 @@ pub trait ComponentId: Sized + ComponentInfo + 'static {
     #[inline(always)]
     fn __register_or_get_id<'a, const MANUAL_REGISTRATION_CHECK: bool>(
         world: impl IntoWorld<'a>,
-    ) -> EntityT {
+    ) -> sys::ecs_entity_t {
         if !Self::IS_GENERIC {
             let index = Self::index() as usize;
             let world = world.world();
@@ -164,7 +165,7 @@ pub trait ComponentId: Sized + ComponentInfo + 'static {
     fn __register_or_get_id_named<'a, const MANUAL_REGISTRATION_CHECK: bool>(
         world: impl IntoWorld<'a>,
         name: &str,
-    ) -> EntityT {
+    ) -> sys::ecs_entity_t {
         if !Self::IS_GENERIC {
             let index = Self::index() as usize;
             let world = world.world();
@@ -252,21 +253,21 @@ pub trait ComponentId: Sized + ComponentInfo + 'static {
     /// # Note
     /// Each world has it's own unique id for the component.
     #[inline(always)]
-    fn id<'a>(world: impl IntoWorld<'a>) -> EntityT {
+    fn id<'a>(world: impl IntoWorld<'a>) -> sys::ecs_entity_t {
         Self::UnderlyingType::__register_or_get_id::<true>(world)
     }
 
     // Not public API.
     #[doc(hidden)]
-    fn __register_lifecycle_hooks(_type_hooks: &mut TypeHooksT) {}
+    fn __register_lifecycle_hooks(_type_hooks: &mut sys::ecs_type_hooks_t) {}
 
     // Not public API.
     #[doc(hidden)]
-    fn __register_default_hooks(_type_hooks: &mut TypeHooksT) {}
+    fn __register_default_hooks(_type_hooks: &mut sys::ecs_type_hooks_t) {}
 
     // Not public API.
     #[doc(hidden)]
-    fn __register_clone_hooks(_type_hooks: &mut TypeHooksT) {}
+    fn __register_clone_hooks(_type_hooks: &mut sys::ecs_type_hooks_t) {}
 
     fn register_ctor_hook<'a>(world: impl IntoWorld<'a>)
     where

--- a/flecs_ecs/src/core/components/cached_ref.rs
+++ b/flecs_ecs/src/core/components/cached_ref.rs
@@ -9,7 +9,7 @@ use crate::sys;
 #[derive(Debug, Clone, Copy)]
 pub struct CachedRef<'a, T: ComponentId + DataComponent> {
     world: WorldRef<'a>,
-    component_ref: RefT,
+    component_ref: sys::ecs_ref_t,
     _marker: PhantomData<T>,
 }
 
@@ -27,11 +27,16 @@ impl<'a, T: ComponentId + DataComponent> CachedRef<'a, T> {
     /// * C++ API: `ref::ref`
     ///
     #[doc(alias = "ref::ref")]
-    pub fn new(world: impl IntoWorld<'a>, entity: impl Into<Entity>, mut id: IdT) -> Self {
+    pub fn new(
+        world: impl IntoWorld<'a>,
+        entity: impl Into<Entity>,
+        mut id: sys::ecs_id_t,
+    ) -> Self {
         // the world we were called with may be a stage; convert it to a world
         // here if that is the case
-        let world_ptr =
-            unsafe { sys::ecs_get_world(world.world_ptr_mut() as *const c_void) as *mut WorldT };
+        let world_ptr = unsafe {
+            sys::ecs_get_world(world.world_ptr_mut() as *const c_void) as *mut sys::ecs_world_t
+        };
 
         if id == 0 {
             id = T::id(world);

--- a/flecs_ecs/src/core/components/component.rs
+++ b/flecs_ecs/src/core/components/component.rs
@@ -88,7 +88,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     ///
     /// * C++ API: `component::get_binding_context`
     #[doc(alias = "component::get_binding_context")]
-    fn get_binding_context(type_hooks: &mut TypeHooksT) -> &mut ComponentBindingCtx {
+    fn get_binding_context(type_hooks: &mut sys::ecs_type_hooks_t) -> &mut ComponentBindingCtx {
         let mut binding_ctx: *mut ComponentBindingCtx = type_hooks.binding_ctx as *mut _;
 
         if binding_ctx.is_null() {
@@ -107,11 +107,11 @@ impl<'a, T: ComponentId> Component<'a, T> {
     ///
     /// * C++ API: `component::get_hooks`
     #[doc(alias = "component::get_hooks")]
-    pub fn get_hooks(&self) -> TypeHooksT {
-        let type_hooks: *const TypeHooksT =
+    pub fn get_hooks(&self) -> sys::ecs_type_hooks_t {
+        let type_hooks: *const sys::ecs_type_hooks_t =
             unsafe { sys::ecs_get_hooks_id(self.world.world_ptr_mut(), *self.id) };
         if type_hooks.is_null() {
-            TypeHooksT::default()
+            sys::ecs_type_hooks_t::default()
         } else {
             unsafe { *type_hooks }
         }
@@ -140,7 +140,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     where
         Func: FnMut(EntityView, &mut T) + 'static,
     {
-        let mut type_hooks: TypeHooksT = self.get_hooks();
+        let mut type_hooks: sys::ecs_type_hooks_t = self.get_hooks();
 
         ecs_assert!(
             type_hooks.on_add.is_none(),
@@ -169,7 +169,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     where
         Func: FnMut(EntityView, &mut T) + 'static,
     {
-        let mut type_hooks: TypeHooksT = self.get_hooks();
+        let mut type_hooks: sys::ecs_type_hooks_t = self.get_hooks();
 
         ecs_assert!(
             type_hooks.on_remove.is_none(),
@@ -198,7 +198,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     where
         Func: FnMut(EntityView, &mut T) + 'static,
     {
-        let mut type_hooks: TypeHooksT = self.get_hooks();
+        let mut type_hooks: sys::ecs_type_hooks_t = self.get_hooks();
 
         ecs_assert!(
             type_hooks.on_set.is_none(),
@@ -251,7 +251,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     }
 
     /// Function to run the on add hook.
-    unsafe extern "C" fn run_add<Func>(iter: *mut IterT)
+    unsafe extern "C" fn run_add<Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(EntityView, &mut T) + 'static,
     {
@@ -266,7 +266,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     }
 
     /// Function to run the on set hook.
-    unsafe extern "C" fn run_set<Func>(iter: *mut IterT)
+    unsafe extern "C" fn run_set<Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(EntityView, &mut T) + 'static,
     {
@@ -281,7 +281,7 @@ impl<'a, T: ComponentId> Component<'a, T> {
     }
 
     /// Function to run the on remove hook.
-    unsafe extern "C" fn run_remove<Func>(iter: *mut IterT)
+    unsafe extern "C" fn run_remove<Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(EntityView, &mut T) + 'static,
     {

--- a/flecs_ecs/src/core/components/lifecycle_traits.rs
+++ b/flecs_ecs/src/core/components/lifecycle_traits.rs
@@ -51,7 +51,7 @@ use crate::core::*;
 use crate::sys;
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn register_lifecycle_actions<T>(type_hooks: &mut TypeHooksT) {
+pub fn register_lifecycle_actions<T>(type_hooks: &mut sys::ecs_type_hooks_t) {
     //type_hooks.ctor = Some(ctor::<T>);
     type_hooks.dtor = Some(dtor::<T>);
     type_hooks.move_dtor = Some(move_dtor::<T>); //same implementation as ctor_move_dtor
@@ -63,20 +63,20 @@ pub fn register_lifecycle_actions<T>(type_hooks: &mut TypeHooksT) {
     //a sparse component tag
 }
 
-pub fn register_ctor_lifecycle_actions<T: Default>(type_hooks: &mut TypeHooksT) {
+pub fn register_ctor_lifecycle_actions<T: Default>(type_hooks: &mut sys::ecs_type_hooks_t) {
     type_hooks.ctor = Some(ctor::<T>);
 }
 
-pub fn register_ctor_panic_lifecycle_actions<T>(_type_hooks: &mut TypeHooksT) {
+pub fn register_ctor_panic_lifecycle_actions<T>(_type_hooks: &mut sys::ecs_type_hooks_t) {
     //type_hooks.ctor = Some(panic_ctor::<T>);
 }
 
-pub fn register_copy_lifecycle_action<T: Clone>(type_hooks: &mut TypeHooksT) {
+pub fn register_copy_lifecycle_action<T: Clone>(type_hooks: &mut sys::ecs_type_hooks_t) {
     type_hooks.copy = Some(copy::<T>);
     type_hooks.copy_ctor = Some(copy_ctor::<T>); //same implementation as copy
 }
 
-pub fn register_copy_panic_lifecycle_action<T>(type_hooks: &mut TypeHooksT) {
+pub fn register_copy_panic_lifecycle_action<T>(type_hooks: &mut sys::ecs_type_hooks_t) {
     type_hooks.copy = Some(panic_copy::<T>);
     type_hooks.copy_ctor = Some(panic_copy::<T>); //same implementation as copy
 }

--- a/flecs_ecs/src/core/entity.rs
+++ b/flecs_ecs/src/core/entity.rs
@@ -86,7 +86,7 @@ impl ComponentId for Entity {
 
     fn __register_or_get_id<'a, const MANUAL_REGISTRATION_CHECK: bool>(
         _world: impl IntoWorld<'a>,
-    ) -> EntityT {
+    ) -> sys::ecs_entity_t {
         // already registered by flecs in World
         unsafe { sys::FLECS_IDecs_entity_tID_ }
     }
@@ -95,7 +95,7 @@ impl ComponentId for Entity {
     fn __register_or_get_id_named<'a, const MANUAL_REGISTRATION_CHECK: bool>(
         _world: impl IntoWorld<'a>,
         _name: &str,
-    ) -> EntityT {
+    ) -> sys::ecs_entity_t {
         // already registered by flecs in World
         unsafe { sys::FLECS_IDecs_entity_tID_ }
     }
@@ -107,7 +107,7 @@ impl ComponentId for Entity {
     }
 
     #[inline]
-    fn id<'a>(_world: impl IntoWorld<'a>) -> IdT {
+    fn id<'a>(_world: impl IntoWorld<'a>) -> sys::ecs_id_t {
         //this is safe because it's already registered in flecs_c / world
         unsafe { sys::FLECS_IDecs_entity_tID_ }
     }

--- a/flecs_ecs/src/core/entity_view/entity_view_const.rs
+++ b/flecs_ecs/src/core/entity_view/entity_view_const.rs
@@ -512,7 +512,7 @@ impl<'a> EntityView<'a> {
 
         let table = Table::new(real_world, table);
 
-        let mut pattern: IdT = *first.into();
+        let mut pattern: sys::ecs_id_t = *first.into();
         let second_id = *second.into();
         if second_id != 0 {
             pattern = ecs_pair(pattern, second_id);
@@ -1694,7 +1694,7 @@ impl<'a> EntityView<'a> {
     where
         T: ComponentId + ComponentType<Enum> + EnumComponentInfo,
     {
-        let component_id: IdT = T::id(self.world);
+        let component_id: sys::ecs_id_t = T::id(self.world);
         // Safety: we know the enum fields are registered because of the previous T::id call
         let enum_constant_entity_id = unsafe { constant.id_variant_unchecked(self.world) };
 
@@ -1783,7 +1783,7 @@ impl<'a> EntityView<'a> {
         &self,
         constant: U,
     ) -> bool {
-        let component_id: IdT = T::id(self.world);
+        let component_id: sys::ecs_id_t = T::id(self.world);
         let enum_constant_entity_id = constant.id_variant(self.world);
 
         self.has_id((component_id, enum_constant_entity_id))
@@ -2427,9 +2427,9 @@ impl<'a> EntityView<'a> {
 // entity observer creation
 impl<'a> EntityView<'a> {
     pub(crate) fn entity_observer_create(
-        world: *mut WorldT,
-        event: EntityT,
-        entity: EntityT,
+        world: *mut sys::ecs_world_t,
+        event: sys::ecs_entity_t,
+        entity: sys::ecs_entity_t,
         binding_ctx: *mut ObserverEntityBindingCtx,
         callback: sys::ecs_iter_action_t,
     ) {
@@ -2455,7 +2455,7 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_observer_delegate::invoke`
     #[doc(alias = "entity_observer_delegate::invoke")]
-    pub(crate) unsafe extern "C" fn run_empty<Func>(iter: *mut IterT)
+    pub(crate) unsafe extern "C" fn run_empty<Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(),
     {
@@ -2483,7 +2483,7 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_observer_delegate::invoke`
     #[doc(alias = "entity_observer_delegate::invoke")]
-    pub(crate) unsafe extern "C" fn run_empty_entity<Func>(iter: *mut IterT)
+    pub(crate) unsafe extern "C" fn run_empty_entity<Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(&mut EntityView),
     {
@@ -2515,7 +2515,7 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_payload_observer_delegate::invoke`
     #[doc(alias = "entity_payload_observer_delegate::invoke")]
-    pub(crate) unsafe extern "C" fn run_payload<C, Func>(iter: *mut IterT)
+    pub(crate) unsafe extern "C" fn run_payload<C, Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(&C),
     {
@@ -2545,7 +2545,7 @@ impl<'a> EntityView<'a> {
     ///
     /// * C++ API: `entity_payload_observer_delegate::invoke`
     #[doc(alias = "entity_payload_observer_delegate::invoke")]
-    pub(crate) unsafe extern "C" fn run_payload_entity<C, Func>(iter: *mut IterT)
+    pub(crate) unsafe extern "C" fn run_payload_entity<C, Func>(iter: *mut sys::ecs_iter_t)
     where
         Func: FnMut(&mut EntityView, &C),
     {
@@ -2652,8 +2652,8 @@ impl<'a> EntityView<'a> {
                 }
             }
         } else {
-            let component_id: IdT = T::id(self.world);
-            let target: IdT = unsafe {
+            let component_id: sys::ecs_id_t = T::id(self.world);
+            let target: sys::ecs_id_t = unsafe {
                 sys::ecs_get_target(self.world.world_ptr_mut(), *self.id, component_id, 0)
             };
 

--- a/flecs_ecs/src/core/event.rs
+++ b/flecs_ecs/src/core/event.rs
@@ -23,8 +23,8 @@ use crate::sys;
 pub struct EventBuilder<'a, T = ()> {
     pub world: WorldRef<'a>,
     pub(crate) desc: sys::ecs_event_desc_t,
-    pub(crate) ids: TypeT,
-    pub(crate) ids_array: [IdT; sys::FLECS_EVENT_DESC_MAX as usize],
+    pub(crate) ids: sys::ecs_type_t,
+    pub(crate) ids_array: [sys::ecs_id_t; sys::FLECS_EVENT_DESC_MAX as usize],
     _phantom: std::marker::PhantomData<T>,
 }
 

--- a/flecs_ecs/src/core/flecs.rs
+++ b/flecs_ecs/src/core/flecs.rs
@@ -2,6 +2,7 @@
 use std::ops::Deref;
 
 use crate::core::*;
+use crate::sys;
 
 #[doc(hidden)]
 pub trait FlecsTrait {}
@@ -47,14 +48,14 @@ macro_rules! create_pre_registered_component {
 
             fn __register_or_get_id<'a, const MANUAL_REGISTRATION_CHECK: bool>(
                 _world: impl IntoWorld<'a>,
-            ) -> EntityT {
+            ) -> sys::ecs_entity_t {
                 $const_name
             }
 
             fn __register_or_get_id_named<'a, const MANUAL_REGISTRATION_CHECK: bool>(
                 _world: impl IntoWorld<'a>,
                 _name: &str,
-            ) -> EntityT {
+            ) -> sys::ecs_entity_t {
                 $const_name
             }
 
@@ -62,7 +63,7 @@ macro_rules! create_pre_registered_component {
                 true
             }
 
-            fn id<'a>(_world: impl IntoWorld<'a>) -> IdT {
+            fn id<'a>(_world: impl IntoWorld<'a>) -> sys::ecs_id_t {
                 $const_name
             }
 
@@ -358,11 +359,11 @@ impl flecs_ecs::core::component_registration::registration_traits::ComponentId f
         Self::get_or_init_index(&INDEX)
     }
 
-    fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_lifecycle_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<()>(type_hooks);
     }
 
-    fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_default_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         const IMPLS_DEFAULT: bool = <() as ComponentInfo>::IMPLS_DEFAULT;
 
         if IMPLS_DEFAULT {
@@ -370,7 +371,7 @@ impl flecs_ecs::core::component_registration::registration_traits::ComponentId f
         }
     }
 
-    fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    fn __register_clone_hooks(type_hooks: &mut sys::ecs_type_hooks_t) {
         const IMPLS_CLONE: bool = <() as ComponentInfo>::IMPLS_CLONE;
 
         if IMPLS_CLONE {

--- a/flecs_ecs/src/core/get_tuple.rs
+++ b/flecs_ecs/src/core/get_tuple.rs
@@ -183,7 +183,7 @@ where
     fn populate_array_ptrs<'a, const SHOULD_PANIC: bool>(
         world: impl IntoWorld<'a>, entity: Entity, record: *const ecs_record_t, components: &mut [*mut c_void]
     ) -> bool {
-        let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut WorldT };
+        let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut sys::ecs_world_t };
         let table = unsafe { (*record).table };
         let entity = *entity;
         let id = <A::OnlyType as ComponentOrPairId>::get_id(world);
@@ -191,7 +191,7 @@ where
         
         let component_ptr = if A::OnlyType::IS_ENUM {
 
-            let target: IdT = unsafe {
+            let target: sys::ecs_id_t = unsafe {
                 sys::ecs_get_target(world_ptr, entity, id, 0)
             };
 
@@ -310,7 +310,7 @@ macro_rules! impl_get_tuple {
                 world: impl IntoWorld<'a>, entity: Entity, record: *const ecs_record_t, components: &mut [*mut c_void]
             ) -> bool {
 
-                let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut WorldT };
+                let world_ptr = unsafe { sys::ecs_get_world(world.world_ptr() as *const c_void) as *mut sys::ecs_world_t };
                 let world_ref = world.world();
                 let table = unsafe { (*record).table };
                 let entity = *entity;
@@ -322,7 +322,7 @@ macro_rules! impl_get_tuple {
 
                     let component_ptr = if $t::OnlyType::IS_ENUM {
 
-                        let target: IdT = unsafe {
+                        let target: sys::ecs_id_t = unsafe {
                             sys::ecs_get_target(world_ptr, entity, id, 0)
                         };
 

--- a/flecs_ecs/src/core/query.rs
+++ b/flecs_ecs/src/core/query.rs
@@ -26,7 +26,7 @@ pub struct Query<T>
 where
     T: QueryTuple,
 {
-    pub(crate) query: NonNull<QueryT>,
+    pub(crate) query: NonNull<sys::ecs_query_t>,
     // this is a leaked box, which is valid during the lifecycle of the query object.
     world_ctx: NonNull<WorldCtx>,
     _phantom: PhantomData<T>,
@@ -74,25 +74,25 @@ where
     T: QueryTuple,
 {
     #[inline(always)]
-    fn retrieve_iter(&self) -> IterT {
+    fn retrieve_iter(&self) -> sys::ecs_iter_t {
         unsafe { sys::ecs_query_iter(self.world_ptr_mut(), self.query.as_ptr()) }
     }
 
     #[inline(always)]
-    fn retrieve_iter_stage<'a>(&self, stage: impl IntoWorld<'a>) -> IterT {
+    fn retrieve_iter_stage<'a>(&self, stage: impl IntoWorld<'a>) -> sys::ecs_iter_t {
         unsafe { sys::ecs_query_iter(stage.world_ptr_mut(), self.query.as_ptr()) }
     }
 
     #[inline(always)]
-    fn iter_next(&self, iter: &mut IterT) -> bool {
+    fn iter_next(&self, iter: &mut sys::ecs_iter_t) -> bool {
         unsafe { sys::ecs_query_next(iter) }
     }
 
-    fn query_ptr(&self) -> *const QueryT {
+    fn query_ptr(&self) -> *const sys::ecs_query_t {
         self.query.as_ptr()
     }
 
-    fn iter_next_func(&self) -> unsafe extern "C" fn(*mut IterT) -> bool {
+    fn iter_next_func(&self) -> unsafe extern "C" fn(*mut sys::ecs_iter_t) -> bool {
         sys::ecs_query_next
     }
 }
@@ -138,7 +138,7 @@ where
     /// * C++ API: `query::query`
     #[doc(alias = "query::query")]
     #[inline]
-    pub unsafe fn new_from(query: NonNull<QueryT>) -> Self {
+    pub unsafe fn new_from(query: NonNull<sys::ecs_query_t>) -> Self {
         sys::flecs_poly_claim_(query.as_ptr() as *mut c_void);
 
         let world_ctx = ecs_get_binding_ctx((*query.as_ptr()).world) as *mut WorldCtx;
@@ -210,7 +210,7 @@ where
 
                 if !query_poly.is_null() {
                     sys::flecs_poly_claim_(query_poly as *mut c_void);
-                    let query = NonNull::new_unchecked(query_poly as *mut QueryT);
+                    let query = NonNull::new_unchecked(query_poly as *mut sys::ecs_query_t);
                     let new_query = Query::<()>::new_from(query);
                     new_query.world().world_ctx_mut().inc_query_ref_count();
                     return Some(new_query);
@@ -264,7 +264,7 @@ where
     ///
     /// * C++ API: `query::get_iter`
     #[doc(alias = "query::get_iter")]
-    unsafe fn get_iter_raw(&mut self) -> IterT {
+    unsafe fn get_iter_raw(&mut self) -> sys::ecs_iter_t {
         unsafe { sys::ecs_query_iter(self.world_ptr_mut(), self.query.as_ptr()) }
     }
 
@@ -301,7 +301,7 @@ where
     ///
     /// * C++ API: `query_base::get_group_info`
     #[doc(alias = "query_base::get_group_info")]
-    pub fn group_info(&self, group_id: impl Into<Entity>) -> *const QueryGroupInfoT {
+    pub fn group_info(&self, group_id: impl Into<Entity>) -> *const sys::ecs_query_group_info_t {
         unsafe { sys::ecs_query_get_group_info(self.query.as_ptr(), *group_id.into()) }
     }
 
@@ -330,7 +330,7 @@ where
     }
 
     /// get the raw `c_ptr` of the query
-    pub fn c_ptr(&self) -> NonNull<QueryT> {
+    pub fn c_ptr(&self) -> NonNull<sys::ecs_query_t> {
         self.query
     }
 }

--- a/flecs_ecs/src/core/query_builder.rs
+++ b/flecs_ecs/src/core/query_builder.rs
@@ -207,7 +207,8 @@ where
 }
 
 // Assuming some imports and definitions from your previous example, and adding the required ones for this example.
-type GroupByFn = extern "C" fn(*mut WorldT, *mut TableT, IdT, *mut c_void) -> u64;
+type GroupByFn =
+    extern "C" fn(*mut sys::ecs_world_t, *mut sys::ecs_table_t, sys::ecs_id_t, *mut c_void) -> u64;
 
 /// Functions to build a query using terms.
 pub trait QueryBuilderImpl<'a>: TermBuilderImpl<'a> {

--- a/flecs_ecs/src/core/query_iter.rs
+++ b/flecs_ecs/src/core/query_iter.rs
@@ -8,8 +8,8 @@ pub struct QueryIter<'a, P, T>
 where
     T: QueryTuple,
 {
-    iter: IterT,
-    iter_next: unsafe extern "C" fn(*mut IterT) -> bool,
+    iter: sys::ecs_iter_t,
+    iter_next: unsafe extern "C" fn(*mut sys::ecs_iter_t) -> bool,
     _phantom: std::marker::PhantomData<&'a (P, T)>,
 }
 
@@ -17,7 +17,10 @@ impl<'a, P, T> QueryIter<'a, P, T>
 where
     T: QueryTuple,
 {
-    pub fn new(iter: IterT, iter_next: unsafe extern "C" fn(*mut IterT) -> bool) -> Self {
+    pub fn new(
+        iter: sys::ecs_iter_t,
+        iter_next: unsafe extern "C" fn(*mut sys::ecs_iter_t) -> bool,
+    ) -> Self {
         Self {
             iter,
             iter_next,
@@ -148,23 +151,23 @@ impl<'a, P, T> IterOperations for QueryIter<'a, P, T>
 where
     T: QueryTuple,
 {
-    fn retrieve_iter(&self) -> IterT {
+    fn retrieve_iter(&self) -> sys::ecs_iter_t {
         self.iter
     }
 
-    fn retrieve_iter_stage<'w>(&self, _stage: impl IntoWorld<'w>) -> IterT {
+    fn retrieve_iter_stage<'w>(&self, _stage: impl IntoWorld<'w>) -> sys::ecs_iter_t {
         panic!("Cannot change the stage of an iterator that already exists. Use retrieve_iter_stage on the underlying query instead.");
     }
 
-    fn iter_next(&self, iter: &mut IterT) -> bool {
+    fn iter_next(&self, iter: &mut sys::ecs_iter_t) -> bool {
         unsafe { (self.iter_next)(iter) }
     }
 
-    fn query_ptr(&self) -> *const QueryT {
+    fn query_ptr(&self) -> *const sys::ecs_query_t {
         self.iter.query
     }
 
-    fn iter_next_func(&self) -> unsafe extern "C" fn(*mut IterT) -> bool {
+    fn iter_next_func(&self) -> unsafe extern "C" fn(*mut sys::ecs_iter_t) -> bool {
         self.iter_next
     }
 }

--- a/flecs_ecs/src/core/table/iter.rs
+++ b/flecs_ecs/src/core/table/iter.rs
@@ -11,7 +11,7 @@ pub(crate) enum IterType {
 }
 
 pub struct TableIter<'a, const IS_RUN: bool = true, P = ()> {
-    iter: &'a mut IterT,
+    iter: &'a mut sys::ecs_iter_t,
     marker: PhantomData<P>,
 }
 
@@ -39,7 +39,7 @@ where
     /// * C++ API: `iter::iter`
     /// # Safety
     /// - caller must ensure that iter.param points to type T
-    pub unsafe fn new(iter: &'a mut IterT) -> Self {
+    pub unsafe fn new(iter: &'a mut sys::ecs_iter_t) -> Self {
         Self {
             iter,
             marker: PhantomData,
@@ -133,7 +133,7 @@ where
     ///
     /// * C++ API: `iter::c_ptr`
     #[doc(alias = "iter::c_ptr")]
-    pub fn iter_mut(&mut self) -> &mut IterT {
+    pub fn iter_mut(&mut self) -> &mut sys::ecs_iter_t {
         self.iter
     }
 
@@ -209,7 +209,8 @@ where
     #[doc(alias = "iter::get_var")]
     pub fn get_var(&self, var_id: i32) -> EntityView<'a> {
         ecs_assert!(var_id != -1, FlecsErrorCode::InvalidParameter, 0);
-        let var = unsafe { sys::ecs_iter_get_var(self.iter as *const _ as *mut IterT, var_id) };
+        let var =
+            unsafe { sys::ecs_iter_get_var(self.iter as *const _ as *mut sys::ecs_iter_t, var_id) };
         let world = self.world();
         EntityView::new_from(world, var)
     }
@@ -743,7 +744,7 @@ where
     ///
     /// * C++ API: `iter::group_id`
     #[doc(alias = "iter::group_id")]
-    pub fn group_id(&self) -> IdT {
+    pub fn group_id(&self) -> sys::ecs_id_t {
         self.iter.group_id
     }
 

--- a/flecs_ecs/src/core/table/mod.rs
+++ b/flecs_ecs/src/core/table/mod.rs
@@ -15,7 +15,7 @@ use crate::sys;
 #[derive(Debug, Clone, Copy)]
 pub struct Table<'a> {
     world: WorldRef<'a>,
-    pub(crate) table: NonNull<TableT>,
+    pub(crate) table: NonNull<sys::ecs_table_t>,
 }
 
 impl<'a> Table<'a> {
@@ -30,7 +30,7 @@ impl<'a> Table<'a> {
     ///
     /// * C++ API: `table::table`
     #[doc(alias = "table::table")]
-    pub fn new(world: impl IntoWorld<'a>, table: NonNull<TableT>) -> Self {
+    pub fn new(world: impl IntoWorld<'a>, table: NonNull<sys::ecs_table_t>) -> Self {
         Self {
             world: world.world(),
             table,
@@ -88,7 +88,7 @@ impl<'a> TableRange<'a> {
     /// The world and table pointers must be valid
     pub(crate) fn new_raw(
         world: impl IntoWorld<'a>,
-        table: NonNull<TableT>,
+        table: NonNull<sys::ecs_table_t>,
         offset: i32,
         count: i32,
     ) -> Self {
@@ -173,7 +173,7 @@ pub trait TableOperations<'a>: IntoTable {
     ///
     /// * C++ API: `table::type_index`
     #[doc(alias = "table::type_index")]
-    fn find_type_index_id(&self, id: IdT) -> Option<i32> {
+    fn find_type_index_id(&self, id: sys::ecs_id_t) -> Option<i32> {
         let index = unsafe {
             sys::ecs_table_get_type_index(self.world().world_ptr(), self.table_ptr_mut(), id)
         };
@@ -289,7 +289,7 @@ pub trait TableOperations<'a>: IntoTable {
     ///
     /// * C++ API: `table::column_index`
     #[doc(alias = "table::column_index")]
-    fn find_column_index_id(&self, id: IdT) -> Option<i32> {
+    fn find_column_index_id(&self, id: sys::ecs_id_t) -> Option<i32> {
         let index = unsafe {
             sys::ecs_table_get_column_index(self.world().world_ptr(), self.table_ptr_mut(), id)
         };
@@ -434,7 +434,7 @@ pub trait TableOperations<'a>: IntoTable {
     ///
     /// * C++ API: `table::has`
     #[doc(alias = "table::has")]
-    fn has_type_id(&self, id: IdT) -> bool {
+    fn has_type_id(&self, id: sys::ecs_id_t) -> bool {
         self.find_type_index_id(id).is_some()
     }
 
@@ -536,7 +536,7 @@ pub trait TableOperations<'a>: IntoTable {
     /// # See also
     ///
     /// * C++ API: `table::get`
-    fn get_mut_untyped(&self, id: IdT) -> Option<*mut c_void> {
+    fn get_mut_untyped(&self, id: sys::ecs_id_t) -> Option<*mut c_void> {
         if let Some(index) = self.find_column_index_id(id) {
             self.column_untyped(index)
         } else {
@@ -701,11 +701,11 @@ impl<'a> TableOperations<'a> for TableRange<'a> {
 
 pub struct TableLock<'a> {
     world: WorldRef<'a>,
-    table: NonNull<TableT>,
+    table: NonNull<sys::ecs_table_t>,
 }
 
 impl<'a> TableLock<'a> {
-    pub fn new(world: impl IntoWorld<'a>, table: NonNull<TableT>) -> Self {
+    pub fn new(world: impl IntoWorld<'a>, table: NonNull<sys::ecs_table_t>) -> Self {
         unsafe { sys::ecs_table_lock(world.world_ptr_mut(), table.as_ptr()) };
         Self {
             world: world.world(),

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -99,23 +99,23 @@ pub mod internals {
         }
 
         #[inline(always)]
-        fn term_mut_at(&mut self, index: i32) -> &mut TermT {
+        fn term_mut_at(&mut self, index: i32) -> &mut sys::ecs_term_t {
             &mut self.query_desc_mut().terms[index as usize]
         }
 
         #[inline(always)]
-        fn current_term_mut(&mut self) -> &mut TermT {
+        fn current_term_mut(&mut self) -> &mut sys::ecs_term_t {
             let index = self.current_term_index();
             self.term_mut_at(index)
         }
 
         #[inline(always)]
-        fn current_term(&self) -> &TermT {
+        fn current_term(&self) -> &sys::ecs_term_t {
             &self.query_desc().terms[self.term_builder().current_term_index as usize]
         }
 
         #[inline(always)]
-        fn term_ref_mut(&mut self) -> &mut TermRefT {
+        fn term_ref_mut(&mut self) -> &mut sys::ecs_term_ref_t {
             let term_mode = self.current_term_ref_mode();
             let term = self.current_term_mut();
 
@@ -209,7 +209,7 @@ pub trait TermBuilderImpl<'a>: Sized + IntoWorld<'a> + internals::QueryConfig<'a
     #[doc(alias = "term::term")]
     fn init_term_from<T: ComponentOrPairId>(&mut self) {
         if !T::IS_PAIR {
-            let id: IdT = T::First::id(self.world());
+            let id: sys::ecs_id_t = T::First::id(self.world());
             self.init_current_term(id);
         } else {
             let world = self.world();

--- a/flecs_ecs/src/core/utility/functions.rs
+++ b/flecs_ecs/src/core/utility/functions.rs
@@ -70,7 +70,7 @@ pub fn ecs_dependson(entity: u64) -> u64 {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 pub fn ecs_has_pair(
-    world: *const WorldT,
+    world: *const sys::ecs_world_t,
     entity: impl Into<Entity>,
     first: impl Into<Entity>,
     second: impl Into<Entity>,
@@ -87,7 +87,7 @@ pub fn ecs_has_pair(
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 pub fn ecs_add_pair(
-    world: *mut WorldT,
+    world: *mut sys::ecs_world_t,
     entity: impl Into<Entity>,
     first: impl Into<Entity>,
     second: impl Into<Entity>,
@@ -231,7 +231,12 @@ pub fn ecs_record_to_row(row: u32) -> i32 {
 /// * `entity`: The ID of the entity.
 /// * `value`: The value to set for the component.
 /// * `id`: The ID of the component type.
-pub(crate) fn set_helper<T: ComponentId>(world: *mut WorldT, entity: u64, value: T, id: u64) {
+pub(crate) fn set_helper<T: ComponentId>(
+    world: *mut sys::ecs_world_t,
+    entity: u64,
+    value: T,
+    id: u64,
+) {
     const {
         assert!(
             std::mem::size_of::<T>() != 0,
@@ -298,7 +303,7 @@ pub(crate) fn set_helper<T: ComponentId>(world: *mut WorldT, entity: u64, value:
 ///
 /// # Returns
 ///
-/// * `IdT`: The entity id with the generation removed.
+/// * `sys::ecs_id_t`: The entity id with the generation removed.
 #[inline(always)]
 pub fn strip_generation(entity: impl Into<Entity>) -> u64 {
     unsafe { sys::ecs_strip_generation(*entity.into()) }
@@ -357,7 +362,7 @@ pub fn get_generation(entity: impl Into<Entity>) -> u32 {
 /// let velocity_ptr: *mut Velocity = ecs_field(it, 2);
 /// ```
 #[inline(always)]
-pub unsafe fn ecs_field<T: ComponentId>(it: *const IterT, index: i32) -> *mut T {
+pub unsafe fn ecs_field<T: ComponentId>(it: *const sys::ecs_iter_t, index: i32) -> *mut T {
     let size = std::mem::size_of::<T>();
     sys::ecs_field_w_size(it, size, index) as *mut T
 }

--- a/flecs_ecs/src/core/utility/traits/into_component_id.rs
+++ b/flecs_ecs/src/core/utility/traits/into_component_id.rs
@@ -1,4 +1,5 @@
 use crate::core::*;
+use crate::sys;
 
 pub trait ComponentOrPairId {
     const IS_ENUM: bool;
@@ -11,7 +12,7 @@ pub trait ComponentOrPairId {
     type First: ComponentId;
     type Second: ComponentId;
 
-    fn get_id<'a>(world: impl IntoWorld<'a>) -> IdT;
+    fn get_id<'a>(world: impl IntoWorld<'a>) -> sys::ecs_id_t;
 
     /// Get the symbol name of the component.
     ///
@@ -34,7 +35,7 @@ where
     type CastType = T;
 
     #[inline]
-    fn get_id<'a>(world: impl IntoWorld<'a>) -> IdT {
+    fn get_id<'a>(world: impl IntoWorld<'a>) -> sys::ecs_id_t {
         T::id(world)
     }
 
@@ -60,7 +61,7 @@ where
     type CastType =
         <ConditionalTypePairSelector<<T as ComponentInfo>::TagType, T, U> as FlecsPairType>::Type;
     #[inline]
-    fn get_id<'a>(world: impl IntoWorld<'a>) -> IdT {
+    fn get_id<'a>(world: impl IntoWorld<'a>) -> sys::ecs_id_t {
         let world = world.world();
         ecs_pair(T::id(world), U::id(world))
     }

--- a/flecs_ecs/src/core/utility/traits/into_id.rs
+++ b/flecs_ecs/src/core/utility/traits/into_id.rs
@@ -1,4 +1,5 @@
 use crate::core::*;
+use crate::sys;
 
 /// Extracts the Ecs ID from a type.
 /// Extension trait from [`Into<Entity>`] for tuples that implement `Into<Entity>`.
@@ -60,7 +61,7 @@ where
 // // We can not implement for T where T : `Into<Entity>`, because it would essentially extend the trait, which we don't want
 // // so we have to implement for each type that implements `Into<Entity>` separately.
 
-impl IntoId for IdT {
+impl IntoId for sys::ecs_id_t {
     const IS_PAIR: bool = false;
 }
 

--- a/flecs_ecs/src/core/utility/traits/into_table.rs
+++ b/flecs_ecs/src/core/utility/traits/into_table.rs
@@ -2,33 +2,33 @@ use crate::core::*;
 use crate::sys;
 
 pub trait IntoTable {
-    fn table_ptr_mut(&self) -> *mut TableT;
+    fn table_ptr_mut(&self) -> *mut sys::ecs_table_t;
 }
 
-impl IntoTable for *mut TableT {
+impl IntoTable for *mut sys::ecs_table_t {
     #[inline]
-    fn table_ptr_mut(&self) -> *mut TableT {
+    fn table_ptr_mut(&self) -> *mut sys::ecs_table_t {
         *self
     }
 }
 
-impl IntoTable for *const TableT {
+impl IntoTable for *const sys::ecs_table_t {
     #[inline]
-    fn table_ptr_mut(&self) -> *mut TableT {
-        *self as *mut TableT
+    fn table_ptr_mut(&self) -> *mut sys::ecs_table_t {
+        *self as *mut sys::ecs_table_t
     }
 }
 
 impl IntoTable for Table<'_> {
     #[inline]
-    fn table_ptr_mut(&self) -> *mut TableT {
+    fn table_ptr_mut(&self) -> *mut sys::ecs_table_t {
         self.table.as_ptr()
     }
 }
 
 impl IntoTable for TableRange<'_> {
     #[inline]
-    fn table_ptr_mut(&self) -> *mut TableT {
+    fn table_ptr_mut(&self) -> *mut sys::ecs_table_t {
         self.table.table.as_ptr()
     }
 }

--- a/flecs_ecs/src/core/utility/traits/into_world.rs
+++ b/flecs_ecs/src/core/utility/traits/into_world.rs
@@ -6,12 +6,12 @@ use crate::sys;
 pub trait IntoWorld<'a> {
     #[doc(hidden)]
     #[inline(always)]
-    fn world_ptr_mut(&self) -> *mut WorldT {
+    fn world_ptr_mut(&self) -> *mut sys::ecs_world_t {
         self.world().raw_world.as_ptr()
     }
     #[doc(hidden)]
     #[inline(always)]
-    fn world_ptr(&self) -> *const WorldT {
+    fn world_ptr(&self) -> *const sys::ecs_world_t {
         self.world().raw_world.as_ptr()
     }
 
@@ -55,7 +55,7 @@ impl<'a> IntoWorld<'a> for &'a World {
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub struct WorldRef<'a> {
-    raw_world: NonNull<WorldT>,
+    raw_world: NonNull<sys::ecs_world_t>,
     components: NonNull<FlecsIdMap>,
     pub(crate) components_array: NonNull<FlecsArray>,
     _marker: PhantomData<&'a ()>,
@@ -68,15 +68,15 @@ impl<'a> WorldRef<'a> {
     pub fn real_world(&self) -> WorldRef<'a> {
         unsafe {
             WorldRef::from_ptr(
-                sys::ecs_get_world(self.world_ptr_mut() as *const c_void) as *mut WorldT
+                sys::ecs_get_world(self.world_ptr_mut() as *const c_void) as *mut sys::ecs_world_t
             )
         }
     }
 
     /// # Safety
-    /// Caller must ensure `raw_world` points to a valid `WorldT`
+    /// Caller must ensure `raw_world` points to a valid `sys::ecs_world_t`
     #[inline(always)]
-    pub unsafe fn from_ptr(raw_world: *mut WorldT) -> Self {
+    pub unsafe fn from_ptr(raw_world: *mut sys::ecs_world_t) -> Self {
         WorldRef {
             raw_world: NonNull::new_unchecked(raw_world),
             components: NonNull::new_unchecked(World::get_components_map_ptr(raw_world)),

--- a/flecs_ecs/src/core/utility/traits/mod.rs
+++ b/flecs_ecs/src/core/utility/traits/mod.rs
@@ -65,8 +65,9 @@ pub mod private {
         /// # See also
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
-        unsafe extern "C" fn execute_each<const CALLED_FROM_RUN: bool, Func>(iter: *mut IterT)
-        where
+        unsafe extern "C" fn execute_each<const CALLED_FROM_RUN: bool, Func>(
+            iter: *mut sys::ecs_iter_t,
+        ) where
             Func: FnMut(T::TupleType<'_>),
         {
             let iter = unsafe { &mut *iter };
@@ -108,7 +109,7 @@ pub mod private {
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
         unsafe extern "C" fn execute_each_entity<const CALLED_FROM_RUN: bool, Func>(
-            iter: *mut IterT,
+            iter: *mut sys::ecs_iter_t,
         ) where
             Func: FnMut(EntityView, T::TupleType<'_>),
         {
@@ -161,7 +162,7 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn execute_each_iter<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_each_iter<Func>(iter: *mut sys::ecs_iter_t)
         where
             Func: FnMut(TableIter<false, P>, usize, T::TupleType<'_>),
         {
@@ -200,7 +201,7 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn execute_run<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_run<Func>(iter: *mut sys::ecs_iter_t)
         where
             Func: FnMut(TableIter<true, P>),
         {
@@ -228,7 +229,7 @@ pub mod private {
         ///
         /// * C++ API: `iter_invoker::invoke_callback`
         #[doc(alias = "iter_invoker::invoke_callback")]
-        unsafe extern "C" fn execute_run_iter<Func>(iter: *mut IterT)
+        unsafe extern "C" fn execute_run_iter<Func>(iter: *mut sys::ecs_iter_t)
         where
             Func: FnMut(TableIter<false, P>, T::TupleSliceType<'_>),
         {

--- a/flecs_ecs/src/core/utility/traits/query_api.rs
+++ b/flecs_ecs/src/core/utility/traits/query_api.rs
@@ -5,19 +5,19 @@ use flecs_ecs::sys;
 
 pub trait IterOperations {
     #[doc(hidden)]
-    fn retrieve_iter(&self) -> IterT;
+    fn retrieve_iter(&self) -> sys::ecs_iter_t;
 
     #[doc(hidden)]
-    fn retrieve_iter_stage<'a>(&self, stage: impl IntoWorld<'a>) -> IterT;
+    fn retrieve_iter_stage<'a>(&self, stage: impl IntoWorld<'a>) -> sys::ecs_iter_t;
 
     #[doc(hidden)]
-    fn iter_next(&self, iter: &mut IterT) -> bool;
+    fn iter_next(&self, iter: &mut sys::ecs_iter_t) -> bool;
 
     #[doc(hidden)]
-    fn iter_next_func(&self) -> unsafe extern "C" fn(*mut IterT) -> bool;
+    fn iter_next_func(&self) -> unsafe extern "C" fn(*mut sys::ecs_iter_t) -> bool;
 
     #[doc(hidden)]
-    fn query_ptr(&self) -> *const QueryT;
+    fn query_ptr(&self) -> *const sys::ecs_query_t;
 }
 
 pub trait QueryAPI<'a, P, T>: IterOperations + IntoWorld<'a>
@@ -1046,7 +1046,7 @@ where
     }
 }
 
-unsafe extern "C" fn __internal_query_execute_each<T, Func>(iter: *mut IterT)
+unsafe extern "C" fn __internal_query_execute_each<T, Func>(iter: *mut sys::ecs_iter_t)
 where
     T: QueryTuple,
     Func: FnMut(T::TupleType<'_>),
@@ -1062,7 +1062,7 @@ where
     }
 }
 
-unsafe extern "C" fn __internal_query_execute_each_entity<T, Func>(iter: *mut IterT)
+unsafe extern "C" fn __internal_query_execute_each_entity<T, Func>(iter: *mut sys::ecs_iter_t)
 where
     T: QueryTuple,
     Func: FnMut(EntityView, T::TupleType<'_>),

--- a/flecs_ecs/tests/flecs/query_builder_test.rs
+++ b/flecs_ecs/tests/flecs/query_builder_test.rs
@@ -1989,18 +1989,18 @@ fn query_builder_16_terms() {
 }
 
 unsafe extern "C" fn group_by_first_id(
-    _world: *mut WorldT,
-    table: *mut TableT,
+    _world: *mut sys::ecs_world_t,
+    table: *mut sys::ecs_table_t,
     _id: u64,
     _ctx: *mut c_void,
 ) -> u64 {
-    let table_type: *const TypeT = sys::ecs_table_get_type(table);
+    let table_type: *const sys::ecs_type_t = sys::ecs_table_get_type(table);
     *(*table_type).array.add(0)
 }
 
 unsafe extern "C" fn group_by_first_id_negated(
-    world: *mut WorldT,
-    table: *mut TableT,
+    world: *mut sys::ecs_world_t,
+    table: *mut sys::ecs_table_t,
     id: u64,
     ctx: *mut c_void,
 ) -> u64 {
@@ -2134,8 +2134,8 @@ fn query_builder_group_by_template() {
 }
 
 unsafe extern "C" fn group_by_rel(
-    world: *mut WorldT,
-    table: *mut TableT,
+    world: *mut sys::ecs_world_t,
+    table: *mut sys::ecs_table_t,
     id: u64,
     _ctx: *mut c_void,
 ) -> u64 {
@@ -2422,7 +2422,7 @@ fn query_builder_group_by_default_func_w_type() {
 }
 
 extern "C" fn callback_group_create(
-    world: *mut WorldT,
+    world: *mut sys::ecs_world_t,
     group_id: u64,
     group_by_ctx: *mut c_void,
 ) -> *mut c_void {
@@ -2435,7 +2435,7 @@ extern "C" fn callback_group_create(
     Box::into_raw(group_id) as *mut c_void
 }
 extern "C" fn callback_group_delete(
-    world: *mut WorldT,
+    world: *mut sys::ecs_world_t,
     group_id: u64,
     ctx: *mut c_void,
     group_by_ctx: *mut c_void,

--- a/flecs_ecs_derive/src/lib.rs
+++ b/flecs_ecs_derive/src/lib.rs
@@ -254,7 +254,7 @@ fn impl_cached_component_data_struct(
     let hook_impl = if !is_generic {
         quote! {
 
-            fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_default_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                 use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
                 const IMPLS_DEFAULT: bool =  #name::IMPLS_DEFAULT;
 
@@ -263,7 +263,7 @@ fn impl_cached_component_data_struct(
                 }
             }
 
-            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                 use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
                 const IMPLS_CLONE: bool = #name::IMPLS_CLONE;
 
@@ -279,7 +279,7 @@ fn impl_cached_component_data_struct(
     } else if contains_lifetime_bound && !contains_any_generic_type {
         quote! {
 
-            fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_default_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                 use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
                 const IMPLS_DEFAULT: bool =  #name::<'_>::IMPLS_DEFAULT;
 
@@ -288,7 +288,7 @@ fn impl_cached_component_data_struct(
                 }
             }
 
-            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                 use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
                 const IMPLS_CLONE: bool = #name::<'_>::IMPLS_CLONE;
 
@@ -303,7 +303,7 @@ fn impl_cached_component_data_struct(
         }
     // } else if contains_any_generic_type && contains_all_default_bound && contains_all_clone_bound {
     //     quote! {
-    //     fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    //     fn __register_default_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
     //         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
     //         const IMPLS_DEFAULT: bool =  #name::#type_generics::IMPLS_DEFAULT;
 
@@ -312,7 +312,7 @@ fn impl_cached_component_data_struct(
     //         }
     //     }
 
-    //     fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    //     fn __register_clone_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
     //         use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
     //         const IMPLS_CLONE: bool = #name::#type_generics::IMPLS_CLONE;
 
@@ -327,7 +327,7 @@ fn impl_cached_component_data_struct(
     //     }
     // } else if contains_any_generic_type && contains_all_default_bound {
     //     quote! {
-    //         fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    //         fn __register_default_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
     //             use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
     //             const IMPLS_DEFAULT: bool =  #name::#type_generics::IMPLS_DEFAULT;
 
@@ -338,7 +338,7 @@ fn impl_cached_component_data_struct(
     //     }
     // } else if contains_any_generic_type && contains_all_clone_bound {
     //     quote! {
-    //         fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+    //         fn __register_clone_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
     //             use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
     //             const IMPLS_CLONE: bool = #name::#type_generics::IMPLS_CLONE;
 
@@ -353,7 +353,7 @@ fn impl_cached_component_data_struct(
     //     }
     } else {
         quote! {
-            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                     flecs_ecs::core::lifecycle_traits::register_copy_panic_lifecycle_action::<#name #type_generics>(
                         type_hooks,
                     );
@@ -368,7 +368,7 @@ fn impl_cached_component_data_struct(
             Self::get_or_init_index(&INDEX)
         }
 
-        fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+        fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t)  {
             flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name #type_generics>(type_hooks);
         }
 
@@ -627,11 +627,11 @@ fn impl_cached_component_data_enum(ast: &mut syn::DeriveInput) -> proc_macro2::T
                 Self::get_or_init_index(&INDEX)
             }
 
-            fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT)  {
+            fn __register_lifecycle_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t)  {
                 flecs_ecs::core::lifecycle_traits::register_lifecycle_actions::<#name>(type_hooks);
             }
 
-            fn __register_default_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_default_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                 use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
                 const IMPLS_DEFAULT: bool =  #name::IMPLS_DEFAULT;
 
@@ -640,7 +640,7 @@ fn impl_cached_component_data_enum(ast: &mut syn::DeriveInput) -> proc_macro2::T
                 }
             }
 
-            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::core::TypeHooksT) {
+            fn __register_clone_hooks(type_hooks: &mut flecs_ecs::sys::ecs_type_hooks_t) {
                 use flecs_ecs::core::component_registration::registration_traits::ComponentInfo;
                 const IMPLS_CLONE: bool = #name::IMPLS_CLONE;
 


### PR DESCRIPTION
Things like `IdT` and so on don't need their own type aliases and we don't gain much from having them. Just use the underlying `sys` type name.