### PR TITLE
Replace calls to world_ptr_mut with world_ptr.

### DIFF
--- a/flecs_ecs/src/addons/system/mod.rs
+++ b/flecs_ecs/src/addons/system/mod.rs
@@ -122,7 +122,7 @@ impl<'a> System<'a> {
     /// * C++ API: `system::ctx`
     #[doc(alias = "system::ctx")]
     pub fn context(&self) -> *mut c_void {
-        unsafe { (*sys::ecs_system_get(self.world.world_ptr_mut(), *self.id())).ctx }
+        unsafe { (*sys::ecs_system_get(self.world.world_ptr(), *self.id())).ctx }
     }
 
     /// Get the underlying query for the system
@@ -133,9 +133,7 @@ impl<'a> System<'a> {
     #[doc(alias = "system::query")]
     pub fn query(&self) -> Query<()> {
         let query = unsafe {
-            NonNull::new_unchecked(
-                (*sys::ecs_system_get(self.world.world_ptr_mut(), *self.id())).query,
-            )
+            NonNull::new_unchecked((*sys::ecs_system_get(self.world.world_ptr(), *self.id())).query)
         };
         unsafe { Query::<()>::new_from(query) }
     }

--- a/flecs_ecs/src/core/id_view.rs
+++ b/flecs_ecs/src/core/id_view.rs
@@ -169,7 +169,7 @@ impl<'a> IdView<'a> {
     /// * C++ API: `entity_view::is_valid`
     #[doc(alias = "entity_view::is_valid")]
     pub fn is_valid(self) -> bool {
-        unsafe { sys::ecs_is_valid(self.world.world_ptr_mut(), *self.id) }
+        unsafe { sys::ecs_is_valid(self.world.world_ptr(), *self.id) }
     }
 
     /// Test if id has specified first

--- a/flecs_ecs/src/core/query.rs
+++ b/flecs_ecs/src/core/query.rs
@@ -75,12 +75,12 @@ where
 {
     #[inline(always)]
     fn retrieve_iter(&self) -> sys::ecs_iter_t {
-        unsafe { sys::ecs_query_iter(self.world_ptr_mut(), self.query.as_ptr()) }
+        unsafe { sys::ecs_query_iter(self.world_ptr(), self.query.as_ptr()) }
     }
 
     #[inline(always)]
     fn retrieve_iter_stage<'a>(&self, stage: impl IntoWorld<'a>) -> sys::ecs_iter_t {
-        unsafe { sys::ecs_query_iter(stage.world_ptr_mut(), self.query.as_ptr()) }
+        unsafe { sys::ecs_query_iter(stage.world_ptr(), self.query.as_ptr()) }
     }
 
     #[inline(always)]
@@ -198,7 +198,7 @@ where
         world: impl IntoWorld<'a>,
         entity: impl Into<Entity>,
     ) -> Option<Query<()>> {
-        let world_ptr = world.world_ptr_mut();
+        let world_ptr = world.world_ptr();
         let entity = *entity.into();
         unsafe {
             if ecs_get_alive(world_ptr, entity) != 0 {
@@ -265,7 +265,7 @@ where
     /// * C++ API: `query::get_iter`
     #[doc(alias = "query::get_iter")]
     unsafe fn get_iter_raw(&mut self) -> sys::ecs_iter_t {
-        unsafe { sys::ecs_query_iter(self.world_ptr_mut(), self.query.as_ptr()) }
+        unsafe { sys::ecs_query_iter(self.world_ptr(), self.query.as_ptr()) }
     }
 
     ///  Returns whether the query data changed since the last iteration.

--- a/flecs_ecs/src/core/utility/traits/id_operations.rs
+++ b/flecs_ecs/src/core/utility/traits/id_operations.rs
@@ -121,7 +121,7 @@ pub trait IdOperations<'a>: IntoWorld<'a> + IntoId + Sized + Copy {
         // C string with a static lifetime. The caller must ensure this invariant.
         // ecs_id_ptr never returns null, so we don't need to check for that.
         if let Ok(str) =
-            unsafe { std::ffi::CStr::from_ptr(sys::ecs_id_str(self.world_ptr_mut(), *self.into())) }
+            unsafe { std::ffi::CStr::from_ptr(sys::ecs_id_str(self.world_ptr(), *self.into())) }
                 .to_str()
         {
             str
@@ -154,7 +154,7 @@ pub trait IdOperations<'a>: IntoWorld<'a> + IntoId + Sized + Copy {
         // SAFETY: We assume that `ecs_id_str` returns a pointer to a null-terminated
         // C string with a static lifetime. The caller must ensure this invariant.
         // ecs_id_ptr never returns null, so we don't need to check for that.
-        let c_str_ptr = unsafe { sys::ecs_id_str(self.world_ptr_mut(), *self.into()) };
+        let c_str_ptr = unsafe { sys::ecs_id_str(self.world_ptr(), *self.into()) };
 
         // SAFETY: We assume the C string is valid UTF-8. This is risky if not certain.
         unsafe { std::str::from_utf8_unchecked(std::ffi::CStr::from_ptr(c_str_ptr).to_bytes()) }


### PR DESCRIPTION
Many things don't need `*mut ecs_world_t` but can use `*const`.